### PR TITLE
feat: Implement tabbed view for financial goals in Planner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,8 @@
 Auto-generated from all feature plans. Last updated: 2026-02-15
 
 ## Active Technologies
+- TypeScript (React 18, CRA / react-scripts 5) + MUI v6 (`@mui/material` — Tabs, Tab already available), React 18 hooks (004-goals-tabbed-view)
+- N/A — tab state is ephemeral (local `useState`); no persistence changes (004-goals-tabbed-view)
 
 - Markdown / N/A (documentation only) + N/A (static documentation files) (003-oss-documentation)
 
@@ -23,6 +25,7 @@ tests/
 Markdown / N/A (documentation only): Follow standard conventions
 
 ## Recent Changes
+- 004-goals-tabbed-view: Added TypeScript (React 18, CRA / react-scripts 5) + MUI v6 (`@mui/material` — Tabs, Tab already available), React 18 hooks
 
 - 003-oss-documentation: Added Markdown / N/A (documentation only) + N/A (static documentation files)
 

--- a/specs/004-goals-tabbed-view/checklists/requirements.md
+++ b/specs/004-goals-tabbed-view/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Tabbed Financial Goals View
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/004-goals-tabbed-view/data-model.md
+++ b/specs/004-goals-tabbed-view/data-model.md
@@ -1,0 +1,102 @@
+# Data Model: Tabbed Financial Goals View
+
+**Feature**: 004-goals-tabbed-view
+**Date**: 2026-02-22
+
+## Overview
+
+This feature involves **no data model changes**. All entities (`FinancialGoal`, `GoalType`) remain identical. The only change is UI state (active tab index) and a label string in the recurring goals table.
+
+---
+
+## Existing Entities (unchanged)
+
+### GoalType (enum)
+
+```
+GoalType
+├── ONE_TIME  → displayed in "One Time" tab
+└── RECURRING → displayed in "Recurring" tab
+```
+
+Location: `src/types/enums.ts`
+No changes.
+
+### FinancialGoal (domain class)
+
+Key fields used by this feature:
+
+| Field | Type | Used by |
+|-------|------|---------|
+| `id` | string | React key |
+| `goalName` | string | Display name |
+| `goalType` | GoalType | Tab routing |
+| `targetDate` | string | pending vs completed split |
+| `getTargetAmount()` | number | Recurring table (yearly amount) |
+| `getInflationAdjustedTargetAmount()` | number | GoalCard display |
+
+Location: `src/domain/FinancialGoals.ts`
+No changes.
+
+---
+
+## New UI State
+
+### GoalBox tab state
+
+| Field | Type | Default | Scope |
+|-------|------|---------|-------|
+| `activeTab` | `0 \| 1` | `0` | Local to `GoalBox/index.tsx` |
+
+- `0` = "One Time" tab
+- `1` = "Recurring" tab
+- Ephemeral: resets to `0` on page reload
+
+---
+
+## Derived Values (computed, not stored)
+
+| Value | Formula | Used in |
+|-------|---------|---------|
+| One Time tab count | `pendingGoals.length + completedGoals.length` | Tab label |
+| Recurring tab count | `recurringGoals.length` | Tab label |
+| pending goals | `goals where goalType === ONE_TIME && targetDate > selectedDate` | One Time tab |
+| completed goals | `goals where goalType === ONE_TIME && targetDate <= selectedDate` | One Time tab sub-section |
+| recurring goals | `goals where goalType === RECURRING` | Recurring tab |
+
+All derivations already exist in `GoalBox/index.tsx` via `useMemo`. No new calculations introduced.
+
+---
+
+## Component Prop Interfaces (unchanged)
+
+### GoalBox props (no change)
+
+```typescript
+type GoalBoxProps = {
+  financialGoals: FinancialGoal[];
+  investmentBreakdownForAllGoals: GoalWiseInvestmentSuggestions[];
+  selectedDate: string;
+  dispatch: Dispatch<PlannerDataAction>;
+  useStyledBox: boolean;
+};
+```
+
+### RecurringGoalsTable props (no change)
+
+```typescript
+type RecurringGoalsTableProps = {
+  recurringGoals: FinancialGoal[];
+  dispatch: Dispatch<PlannerDataAction>;
+};
+```
+
+### GoalList props (no change)
+
+```typescript
+type GoalListProps = {
+  investmentBreakdownForAllGoals: GoalWiseInvestmentSuggestions[];
+  goals: FinancialGoal[];
+  dispatch: Dispatch<PlannerDataAction>;
+};
+```

--- a/specs/004-goals-tabbed-view/plan.md
+++ b/specs/004-goals-tabbed-view/plan.md
@@ -1,0 +1,141 @@
+# Implementation Plan: Tabbed Financial Goals View
+
+**Branch**: `004-goals-tabbed-view` | **Date**: 2026-02-22 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/004-goals-tabbed-view/spec.md`
+
+## Summary
+
+Replace the current stacked three-section layout (Financial Goals / Completed Goals / Recurring Goals) in `GoalBox` with a two-tab interface ("One Time (N)" and "Recurring (N)") using MUI Tabs. The "One Time" tab preserves the active/completed sub-section structure within it. The "Recurring" tab renames the existing "Monthly Target" column header to "Yearly Target". No new dependencies, no data-model changes, no backend involvement.
+
+## Technical Context
+
+**Language/Version**: TypeScript (React 18, CRA / react-scripts 5)
+**Primary Dependencies**: MUI v6 (`@mui/material` — Tabs, Tab already available), React 18 hooks
+**Storage**: N/A — tab state is ephemeral (local `useState`); no persistence changes
+**Testing**: Jest + React Testing Library via `react-scripts test`
+**Target Platform**: Browser (SPA, deployed via GitHub Pages)
+**Project Type**: Single frontend project
+**Performance Goals**: Tab switch must be perceptually instant (pure in-memory filter; no async work)
+**Constraints**: No new npm dependencies; changes scoped to `src/pages/Planner/components/`
+**Scale/Scope**: UI-only change affecting 2 existing components (`GoalBox/index.tsx`, `RecurringGoalsTable/index.tsx`) and 1 supporting file (`GoalBox/goalList.tsx`)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked post-design.*
+
+| Principle | Assessment | Notes |
+|-----------|-----------|-------|
+| I. Clear Layering | ✅ Pass | Tab selection state lives in `GoalBox` (UI layer). No business logic moves into components. `FinancialGoal` domain class untouched. |
+| II. Feature Co-location | ✅ Pass | All changes are within `src/pages/Planner/components/`. No shared `src/components/` files modified. |
+| III. Upgrade-Friendly Boundaries | ✅ Pass | MUI `Tabs`/`Tab` imported from `@mui/material` public entry point only. No deep imports. |
+| IV. Type Safety | ✅ Pass | New tab state typed as `0 \| 1` (tab index). No `any` introduced. |
+| V. Predictable Change | ✅ Pass | No financial calculation logic changed. Label rename in `RecurringGoalsTable` is a string constant — no new unit test required. Existing tests unaffected. |
+
+No violations. No complexity tracking required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-goals-tabbed-view/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (files touched)
+
+```text
+src/
+└── pages/
+    └── Planner/
+        └── components/
+            ├── GoalBox/
+            │   ├── index.tsx          # PRIMARY CHANGE: add Tabs, tab state, empty states
+            │   └── goalList.tsx       # MINOR CLEANUP: remove redundant RECURRING filter
+            └── RecurringGoalsTable/
+                └── index.tsx          # LABEL CHANGE: "Monthly Target" → "Yearly Target"
+```
+
+**Structure Decision**: Single frontend project. All changes are page-local to `src/pages/Planner/components/` per Constitution Principle II. No new files created.
+
+## Phase 0: Research
+
+*All NEEDS CLARIFICATION items resolved from spec. Minimal external research needed — all dependencies already in use.*
+
+See [research.md](./research.md).
+
+## Phase 1: Design & Contracts
+
+*No backend API. No new entities. Component prop interfaces are the "contracts".*
+
+See [data-model.md](./data-model.md) and [quickstart.md](./quickstart.md).
+
+## Implementation Design
+
+### Change 1 — `GoalBox/index.tsx` (primary change)
+
+**What changes**: Replace the three `Grid` blocks (pendingGoals / completedGoals / recurringGoals) with a `Tabs` + `Tab` control. Tab index `0` = "One Time", Tab index `1` = "Recurring".
+
+**Tab label formula**:
+- "One Time (N)" where N = `pendingGoals.length + completedGoals.length`
+- "Recurring (N)" where N = `recurringGoals.length`
+
+**Tab 0 — One Time content**:
+- If both pending and completed are empty → empty state message: "No one-time goals added yet."
+- If pending > 0 → render "Financial Goals" sub-heading + `<GoalList goals={pendingGoals} />`
+- If completed > 0 → render "Completed Goals" sub-heading + `<GoalList goals={completedGoals} />`
+
+**Tab 1 — Recurring content**:
+- If recurringGoals is empty → empty state message: "No recurring goals added yet."
+- Otherwise → render `<GoalList goals={recurringGoals} />`
+
+**New state**:
+```typescript
+const [activeTab, setActiveTab] = useState<0 | 1>(0);
+```
+
+**MUI components used** (all already in `@mui/material`):
+- `Tabs`, `Tab` — tab control
+- `Box` — tab panel wrapper
+- `Typography` — empty state and sub-section headings
+
+**`useStyledBox` prop**: The existing `StyledBox` wrapper is applied at the `GoalBox` level (one box wrapping the whole tabbed area), not per-section as before. This simplifies the rendering logic.
+
+---
+
+### Change 2 — `RecurringGoalsTable/index.tsx` (label only)
+
+**What changes**: One string constant in the `TableHead`:
+
+```diff
+- Monthly Target
++ Yearly Target
+```
+
+No logic, no calculation, no type changes.
+
+---
+
+### Change 3 — `GoalBox/goalList.tsx` (minor cleanup)
+
+**What changes**: `GoalList` currently receives a mixed array and internally splits RECURRING from ONE_TIME. With the tabbed approach, `GoalBox` now passes pre-filtered arrays — pending one-time goals, completed one-time goals, or recurring goals — so the internal split in `GoalList` is redundant.
+
+**Decision**: Remove the internal `recurringGoals`/`oneTimeGoals` filter split. `GoalList` renders whatever goals it receives using the appropriate renderer (GoalCard for ONE_TIME, RecurringGoalsTable for RECURRING). This keeps `GoalList` a thin renderer without hidden routing logic.
+
+*Alternative considered*: Leave `goalList.tsx` unchanged. Rejected because it would leave dead branching logic (`recurringGoals` filter) that never fires after the tab refactor — a Constitution Principle I violation (hidden logic in UI).*
+
+---
+
+### Empty State Component
+
+No new shared component needed. Empty states are simple inline `Typography` blocks within `GoalBox`. If the same pattern is needed elsewhere later, extraction is straightforward.
+
+---
+
+### Tab Accessibility
+
+MUI `Tabs` handles ARIA roles (`role="tablist"`, `role="tab"`, `aria-selected`) automatically. Each tab panel wrapped in a `Box` with `role="tabpanel"` and `hidden` attribute when inactive, following MUI's recommended accessible tab panel pattern.

--- a/specs/004-goals-tabbed-view/quickstart.md
+++ b/specs/004-goals-tabbed-view/quickstart.md
@@ -1,0 +1,99 @@
+# Quickstart: Tabbed Financial Goals View
+
+**Feature**: 004-goals-tabbed-view
+**Date**: 2026-02-22
+
+## What's Changing
+
+Three localized edits to existing files. No new files. No new dependencies.
+
+| File | Change Type | Summary |
+|------|-------------|---------|
+| `src/pages/Planner/components/GoalBox/index.tsx` | Refactor | Add MUI Tabs; replace stacked sections with tab panels |
+| `src/pages/Planner/components/RecurringGoalsTable/index.tsx` | Label fix | `"Monthly Target"` → `"Yearly Target"` |
+| `src/pages/Planner/components/GoalBox/goalList.tsx` | Cleanup | Remove redundant RECURRING/ONE_TIME internal split |
+
+---
+
+## GoalBox/index.tsx — Key Changes
+
+### 1. Add tab state
+
+```typescript
+const [activeTab, setActiveTab] = useState<0 | 1>(0);
+```
+
+### 2. Compute tab counts
+
+```typescript
+const oneTimeCount = pendingGoals.length + completedGoals.length;
+const recurringCount = recurringGoals.length;
+```
+
+### 3. Replace stacked Grid sections with Tabs
+
+```tsx
+<Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)}>
+  <Tab label={`One Time (${oneTimeCount})`} />
+  <Tab label={`Recurring (${recurringCount})`} />
+</Tabs>
+
+{/* Tab 0: One Time */}
+<Box role="tabpanel" hidden={activeTab !== 0}>
+  {oneTimeCount === 0 ? (
+    <Typography>No one-time goals added yet.</Typography>
+  ) : (
+    <>
+      {pendingGoals.length > 0 && (
+        <>
+          <Typography variant="h6" fontWeight="bold">Financial Goals</Typography>
+          <GoalList goals={pendingGoals} ... />
+        </>
+      )}
+      {completedGoals.length > 0 && (
+        <>
+          <Typography variant="h6" fontWeight="bold">Completed Goals</Typography>
+          <GoalList goals={completedGoals} ... />
+        </>
+      )}
+    </>
+  )}
+</Box>
+
+{/* Tab 1: Recurring */}
+<Box role="tabpanel" hidden={activeTab !== 1}>
+  {recurringCount === 0 ? (
+    <Typography>No recurring goals added yet.</Typography>
+  ) : (
+    <GoalList goals={recurringGoals} ... />
+  )}
+</Box>
+```
+
+---
+
+## RecurringGoalsTable/index.tsx — Label Fix
+
+Find and replace one string in `TableHead`:
+
+```diff
+- Monthly Target
++ Yearly Target
+```
+
+---
+
+## GoalBox/goalList.tsx — Cleanup
+
+Remove the internal goal type split (lines 22–27 in current file). After the tab refactor, `GoalBox` passes pre-filtered arrays, so `GoalList` no longer needs to re-route by type. It renders whatever it receives directly (GoalCard for ONE_TIME goals, RecurringGoalsTable for RECURRING goals).
+
+---
+
+## Verify
+
+```bash
+npm run build          # must pass
+npm test -- --watchAll=false  # must pass
+```
+
+No new test files required. The label change and tab state are covered by the existing build + type check.

--- a/specs/004-goals-tabbed-view/research.md
+++ b/specs/004-goals-tabbed-view/research.md
@@ -1,0 +1,65 @@
+# Research: Tabbed Financial Goals View
+
+**Feature**: 004-goals-tabbed-view
+**Date**: 2026-02-22
+
+## Summary
+
+No external unknowns. All technology is already in use in the project. Research confirms the implementation approach is straightforward with no new dependencies.
+
+---
+
+## Decision 1: Tab Component Choice
+
+**Decision**: Use MUI `Tabs` + `Tab` from `@mui/material` (already installed at v6.1.7).
+
+**Rationale**: MUI Tabs are already the project's UI component library. They provide built-in accessibility (ARIA), keyboard navigation, and theme integration at zero additional cost. No new dependency required.
+
+**Alternatives considered**:
+- Custom CSS tab implementation — rejected: unnecessary work when MUI Tabs already exist in the dependency tree.
+- React Router tabs (URL-based) — rejected: spec explicitly states tab state is ephemeral; no URL routing change required.
+
+---
+
+## Decision 2: Tab State Location
+
+**Decision**: `useState<0 | 1>(0)` local to `GoalBox/index.tsx`.
+
+**Rationale**: Tab selection is a pure UI concern with no cross-component dependencies. Local state is the simplest correct solution. Lifting to a context or global store would violate Constitution Principle I (no hidden business logic) and over-engineer a transient display preference.
+
+**Alternatives considered**:
+- URL query param (`?tab=recurring`) — rejected: spec says ephemeral; adds routing complexity.
+- localStorage persistence — rejected: not specified; adds unnecessary coupling to storage layer.
+
+---
+
+## Decision 3: GoalList Cleanup
+
+**Decision**: Remove the internal RECURRING/ONE_TIME filter split from `GoalList` after `GoalBox` takes ownership of routing by goal type.
+
+**Rationale**: After the tab refactor, `GoalBox` passes pre-filtered arrays (pending one-time, completed one-time, or recurring) to `GoalList`. The existing internal split in `goalList.tsx` would become dead code — a Constitution Principle I violation. Removing it makes `GoalList` a pure renderer.
+
+**Alternatives considered**:
+- Leave `goalList.tsx` unchanged — rejected: leaves unreachable branching logic after refactor.
+
+---
+
+## Decision 4: StyledBox Wrapper Scope
+
+**Decision**: Apply one `StyledBox` wrapping the entire tabbed area (Tabs + panel content), not per-section as before.
+
+**Rationale**: The existing `useStyledBox` prop was used to wrap each section independently. With tabs, a single wrapper around the whole tab control is cleaner and produces the same visual result.
+
+---
+
+## Decision 5: Empty State Rendering
+
+**Decision**: Inline `Typography` within `GoalBox` for empty states. No new shared component.
+
+**Rationale**: Empty state messages are simple text, used only in this one location. Constitution Principle V discourages premature abstraction. If reuse is needed later, extraction is a one-step refactor.
+
+---
+
+## No Open Items
+
+All NEEDS CLARIFICATION markers from spec are resolved. No blocking unknowns remain.

--- a/specs/004-goals-tabbed-view/spec.md
+++ b/specs/004-goals-tabbed-view/spec.md
@@ -1,0 +1,104 @@
+# Feature Specification: Tabbed Financial Goals View
+
+**Feature Branch**: `004-goals-tabbed-view`
+**Created**: 2026-02-22
+**Status**: Draft
+**Input**: User description: "At the moment, the Financial goals are split into two sections, long term and recurring goals. We need a better way to show this. They are becoming too long. The recurring goals also show yearly target as monthly target by mistake. Can the section be tabbed to show one time and recurring goals?"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Switch Between Goal Types via Tabs (Priority: P1)
+
+A user with many financial goals visits the Planner page. Instead of scrolling through a long page that mixes one-time and recurring goals in sequential sections, they see a tabbed interface with "One Time" and "Recurring" as tabs. Clicking a tab shows only the goals of that type, keeping the view focused and manageable.
+
+**Why this priority**: This is the core request — replacing the two-section scroll layout with a tabbed layout. It directly reduces visual clutter and is the primary UX improvement.
+
+**Independent Test**: Can be fully tested by loading the Planner with at least one one-time goal and one recurring goal, verifying that two tabs appear and each tab shows only its respective goals.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has both one-time and recurring goals, **When** they open the Planner page, **Then** they see a tab control with "One Time (N)" and "Recurring (N)" tabs above the goals area, where N is the count of goals in each category.
+2. **Given** the goals view is open, **When** the user clicks the "One Time" tab, **Then** only one-time (non-recurring) goals are displayed.
+3. **Given** the goals view is open, **When** the user clicks the "Recurring" tab, **Then** only recurring goals are displayed.
+4. **Given** the user is on the "Recurring" tab, **When** they switch to "One Time", **Then** the recurring goals are hidden and one-time goals appear without a full page reload.
+
+---
+
+### User Story 2 - Correct Target Amount Label for Recurring Goals (Priority: P2)
+
+A user reviews their recurring goals and sees a column labelled "Monthly Target". The value shown is actually the yearly target, which is misleading. After this fix, the column label is corrected to "Yearly Target" so it accurately reflects the stored value, removing the confusion without any recalculation.
+
+**Why this priority**: This is a data accuracy bug that misleads users about their financial obligations. It must be fixed as part of this work since it affects trust in the planner.
+
+**Independent Test**: Can be fully tested by viewing a recurring goal with a known yearly target and confirming the column header reads "Yearly Target" and the displayed value matches the stored yearly amount exactly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a recurring goal has a yearly target of ₹120,000, **When** the recurring goals tab is viewed, **Then** the displayed amount under "Yearly Target" is ₹120,000.
+2. **Given** a recurring goal is displayed, **When** the user reads the column header, **Then** the label reads "Yearly Target" and the value shown is the full yearly amount — not a monthly calculation.
+
+---
+
+### User Story 3 - Default Tab and Empty State Handling (Priority: P3)
+
+A user who has only one-time goals (or only recurring goals) opens the Planner. The tabbed view defaults to the "One Time" tab. If the active tab has no goals, a clear empty state message is shown instead of a blank area.
+
+**Why this priority**: Ensures the tabbed layout is robust for all user configurations and prevents confusion from blank or broken-looking views.
+
+**Independent Test**: Can be tested by loading the planner with only one goal type and verifying the default tab and empty state render correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user opens the Planner for the first time with goals, **When** the goals section loads, **Then** the "One Time" tab is selected by default.
+2. **Given** the user has no recurring goals, **When** they click the "Recurring" tab, **Then** they see a friendly message indicating no recurring goals exist (not a blank section).
+3. **Given** the user has no one-time goals, **When** the page loads, **Then** the "One Time" tab is still the default but shows an appropriate empty state message.
+
+---
+
+### Edge Cases
+
+- What happens when a user has no goals at all? The tabbed control should still render, with both tabs showing empty state messages.
+- What happens if new goals are added while the user is on a tab? The tab content should reflect the latest state without requiring a page refresh.
+- What happens if a goal's type changes? It should disappear from the current tab and appear in the correct one immediately.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The goals section MUST replace the current stacked two-section layout with a tabbed interface containing exactly two tabs: "One Time (N)" and "Recurring (N)", where N is the count of goals in that category, updated reactively as goals are added or removed.
+- **FR-002**: The "One Time" tab MUST display all goals of type ONE_TIME in two explicit sub-sections: active/pending goals first, followed by a "Completed Goals" sub-section below, preserving the existing card layout.
+- **FR-003**: The "Recurring" tab MUST display all goals of type RECURRING using the existing table layout.
+- **FR-004**: The tabbed view MUST default to the "One Time" tab on initial load.
+- **FR-005**: The recurring goals table MUST rename the column label from "Monthly Target" to "Yearly Target" and display the stored yearly target amount without any recalculation.
+- **FR-006**: When a tab contains no goals, the system MUST display a non-blank empty state message appropriate to that tab (e.g., "No recurring goals added yet").
+- **FR-007**: Tab switching MUST be instantaneous with no full-page reload or data re-fetch.
+
+### Key Entities
+
+- **GoalType**: Classification with two values — ONE_TIME and RECURRING — used to determine which tab a goal belongs to.
+- **FinancialGoal**: Core goal entity with name, type, target amount, and date range; the target amount for recurring goals is a yearly figure and is displayed as-is under the "Yearly Target" label.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can switch between goal types in under 1 second with no perceptible delay.
+- **SC-002**: The recurring goals table column is labelled "Yearly Target" and the displayed value matches the stored yearly target exactly — zero mismatch between label and value.
+- **SC-003**: Users with 5 or more total goals can view either goal type without scrolling past irrelevant goals of the other type.
+- **SC-004**: Both tab empty states are visually distinct from a loading state — users always know whether no goals exist or whether data is still loading.
+
+## Clarifications
+
+### Session 2026-02-22
+
+- Q: Should tab labels include a goal count indicator? → A: Yes — show count in the tab label, e.g., "One Time (3)", "Recurring (2)". Count updates reactively as goals change.
+- Q: How should the recurring goals amount mismatch be fixed — recalculate to monthly or relabel to yearly? → A: Relabel the column to "Yearly Target" and display the stored yearly amount as-is. No recalculation needed.
+- Q: Within the "One Time" tab, should completed goals remain visible as a sub-section? → A: Yes — keep as a sub-section within the tab: active goals first, completed goals below with a "Completed Goals" heading.
+
+## Assumptions
+
+- The "One Time" tab displays two explicit sub-sections: active/pending goals first, then a "Completed Goals" sub-section below — matching the existing layout, now contained within the tab.
+- Tab selection state is ephemeral (resets on page reload); no URL routing change is required.
+- The fix for the recurring goals amount display is a label change only: the column header is renamed from "Monthly Target" to "Yearly Target". The stored yearly value is displayed without any recalculation.
+- No changes are needed to the goal creation or editing flows as part of this feature.
+- The tabbed layout applies only to the goals section of the Planner page, not to any other part of the app.

--- a/specs/004-goals-tabbed-view/tasks.md
+++ b/specs/004-goals-tabbed-view/tasks.md
@@ -1,0 +1,165 @@
+# Tasks: Tabbed Financial Goals View
+
+**Input**: Design documents from `/specs/004-goals-tabbed-view/`
+**Prerequisites**: plan.md ✅ spec.md ✅ research.md ✅ data-model.md ✅ quickstart.md ✅
+
+**Tests**: Not requested in spec. No test tasks generated.
+
+**Organization**: Tasks grouped by user story. Three files change total — no new files, no new dependencies.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to
+- Exact file paths included in all descriptions
+
+---
+
+## Phase 1: Setup (Baseline Verification)
+
+**Purpose**: Confirm the current build and tests pass before making any changes.
+
+- [x] T001 Verify the project builds cleanly by running `npm run build` and confirm zero errors as the baseline
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Clean up `GoalList` so it is a pure renderer that does not re-route goals by type. After the tab refactor, `GoalBox` owns all goal-type routing and passes pre-filtered arrays to `GoalList`. The existing internal split in `goalList.tsx` would become dead branching logic (Constitution Principle I violation) if left in place.
+
+**⚠️ CRITICAL**: Complete before US1 tab implementation to avoid conflicting logic.
+
+- [x] T002 In `src/pages/Planner/components/GoalBox/goalList.tsx`: remove the `recurringGoals` and `oneTimeGoals` filter variables (lines 22–27). Update the render to pass `goals` directly — render `RecurringGoalsTable` when any goal in the array is `RECURRING` type, or `GoalCard` rows when goals are `ONE_TIME` type. Verify the component still renders correctly for both types when called with a pre-filtered array.
+
+**Checkpoint**: `goalList.tsx` is now a pure renderer. `GoalBox` is ready for tab implementation.
+
+---
+
+## Phase 3: User Story 1 — Tab Interface (Priority: P1) 🎯 MVP
+
+**Goal**: Replace the stacked three-section layout (Financial Goals / Completed Goals / Recurring Goals) with a two-tab interface ("One Time (N)" / "Recurring (N)") that defaults to the "One Time" tab.
+
+**Independent Test**: Load the Planner with at least one ONE_TIME goal and one RECURRING goal. Confirm two tabs appear with correct counts. Click each tab and confirm only the goals of that type are visible. Verify switching tabs is instantaneous.
+
+### Implementation
+
+- [x] T003 [US1] In `src/pages/Planner/components/GoalBox/index.tsx`: add `useState<0 | 1>(0)` import from React and declare `const [activeTab, setActiveTab] = useState<0 | 1>(0)` inside the component body for tab selection state
+- [x] T004 [US1] In `src/pages/Planner/components/GoalBox/index.tsx`: compute `const oneTimeCount = pendingGoals.length + completedGoals.length` and `const recurringCount = recurringGoals.length` using the existing `useMemo`-derived arrays
+- [x] T005 [US1] In `src/pages/Planner/components/GoalBox/index.tsx`: import `Tabs` and `Tab` from `@mui/material` and replace the existing three-Grid stacked return block with a single container holding a `<Tabs value={activeTab} onChange={(_, v) => setActiveTab(v as 0 | 1)}>` with two `<Tab>` children labelled `\`One Time (${oneTimeCount})\`` and `\`Recurring (${recurringCount})\``
+- [x] T006 [US1] In `src/pages/Planner/components/GoalBox/index.tsx`: implement Tab 0 panel as a `<Box role="tabpanel" hidden={activeTab !== 0}>` containing: a "Financial Goals" `Typography` h6 heading + `<GoalList>` for `pendingGoals` (rendered only when `pendingGoals.length > 0`), followed by a "Completed Goals" `Typography` h6 heading + `<GoalList>` for `completedGoals` (rendered only when `completedGoals.length > 0`)
+- [x] T007 [US1] In `src/pages/Planner/components/GoalBox/index.tsx`: implement Tab 1 panel as a `<Box role="tabpanel" hidden={activeTab !== 1}>` containing `<GoalList goals={recurringGoals} ...>` (rendered only when `recurringGoals.length > 0`). Wrap the entire Tabs + panels structure in `<StyledBox>` when `useStyledBox` is true, replacing the per-section `StyledBox` calls from the old layout. Remove the three now-unused helper functions `getPendingGoals()`, `getCompletedGoals()`, `getRecurringGoals()`.
+
+**Checkpoint**: US1 fully functional. Tab switching works. Goal counts show in labels. Active/completed sub-sections appear within the "One Time" tab. Build must pass.
+
+---
+
+## Phase 4: User Story 2 — Yearly Target Label Fix (Priority: P2)
+
+**Goal**: Correct the misleading "Monthly Target" column header in the recurring goals table to "Yearly Target" so it accurately reflects the stored yearly amount.
+
+**Independent Test**: View a recurring goal with a known yearly target. Confirm the column header reads "Yearly Target" and the displayed value matches the stored yearly amount exactly.
+
+### Implementation
+
+- [x] T008 [P] [US2] In `src/pages/Planner/components/RecurringGoalsTable/index.tsx`: change the `TableCell` text in `TableHead` from `Monthly Target` to `Yearly Target` (line 42 of current file). No other changes to this file.
+
+**Checkpoint**: US2 complete. One string changed. Build must pass.
+
+---
+
+## Phase 5: User Story 3 — Empty States and Default Tab (Priority: P3)
+
+**Goal**: When a tab contains no goals, display a clear empty state message instead of a blank area. "One Time" tab is the default on load.
+
+**Independent Test**: Load the Planner with no recurring goals. Click the "Recurring" tab — confirm a message like "No recurring goals added yet." appears. Load with no one-time goals — confirm the "One Time" tab shows an appropriate empty state. Verify the "One Time" tab is always selected by default on page load.
+
+### Implementation
+
+- [x] T009 [US3] In `src/pages/Planner/components/GoalBox/index.tsx`: inside the Tab 0 panel (`hidden={activeTab !== 0}`), add a condition: when `oneTimeCount === 0`, render a `<Typography variant="body2" sx={{ color: 'text.secondary', py: 2 }}>No one-time goals added yet.</Typography>` in place of the sub-section content. The `useState(0)` default (added in T003) already satisfies the "One Time" tab as default — no additional change needed.
+- [x] T010 [US3] In `src/pages/Planner/components/GoalBox/index.tsx`: inside the Tab 1 panel (`hidden={activeTab !== 1}`), add a condition: when `recurringCount === 0`, render a `<Typography variant="body2" sx={{ color: 'text.secondary', py: 2 }}>No recurring goals added yet.</Typography>` in place of the GoalList content.
+
+**Checkpoint**: US3 complete. All three user stories functional. Both tabs have empty states. Build and tests must pass.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Cleanup and final verification.
+
+- [x] T011 [P] In `src/pages/Planner/components/GoalBox/index.tsx`: review the final file for any unused imports left over from the old stacked layout (e.g. `Grid2`, unused `useMemo` dependencies) and remove them to keep the import list clean
+- [x] T012 Run `npm run build` and confirm zero TypeScript errors and zero build warnings related to changed files
+- [x] T013 Run `npm test -- --watchAll=false` and confirm all existing tests pass with no regressions
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — run immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — blocks US1
+- **US1 (Phase 3)**: Depends on Phase 2 completion
+- **US2 (Phase 4)**: Independent of all other phases — can run in parallel with any phase after Phase 1
+- **US3 (Phase 5)**: Depends on US1 completion (tab panels must exist before empty states can be added)
+- **Polish (Phase 6)**: Depends on US1, US2, US3 all complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Foundational phase — no dependency on US2 or US3
+- **US2 (P2)**: Fully independent — touches a different file from US1/US3
+- **US3 (P3)**: Depends on US1 (adds conditions inside panels created by US1)
+
+### Within Each User Story
+
+- T003 → T004 → T005 → T006 → T007 (sequential within US1 — each task builds on the previous)
+- T008 standalone (US2)
+- T009 and T010 can run in parallel within US3 (same file, different panels, no conflict if done sequentially)
+
+### Parallel Opportunities
+
+- **US2 (T008)** can be done any time after T001 — completely independent file
+- **T011** (import cleanup) can run in parallel with T012/T013 in polish phase
+- With two developers: Developer A handles US1 + US3 (GoalBox); Developer B handles US2 (RecurringGoalsTable) simultaneously
+
+---
+
+## Parallel Example: Maximum Parallelism
+
+```text
+# After T001 (baseline verify):
+
+Thread A: T002 → T003 → T004 → T005 → T006 → T007 → T009 → T010
+Thread B: T008 (US2 — completely independent, different file)
+
+# After both threads complete:
+T011 [P] + T012 + T013
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Verify baseline (T001)
+2. Complete Phase 2: GoalList cleanup (T002)
+3. Complete Phase 3: Tab interface (T003–T007)
+4. **STOP and VALIDATE**: Two tabs visible, counts correct, switching works, active/completed sub-sections inside "One Time" tab
+5. Ship MVP — recurring label fix and empty states can follow
+
+### Incremental Delivery
+
+1. T001–T007: Tab interface live → users can switch between goal types ✅
+2. T008: Label fix live → recurring goals correctly labelled "Yearly Target" ✅
+3. T009–T010: Empty states live → no blank tabs when goals are missing ✅
+4. T011–T013: Clean build confirmed ✅
+
+---
+
+## Notes
+
+- All changes are within `src/pages/Planner/components/` — no shared component or domain changes
+- No new npm packages — `Tabs` and `Tab` are already in `@mui/material` v6
+- MUI Tabs handle ARIA automatically (`role="tablist"`, `aria-selected`) — no extra accessibility work needed
+- `[P]` = different file or independent section, safe to parallelize
+- Commit after each completed checkpoint to keep changes reviewable

--- a/src/pages/Planner/components/GoalBox/goalList.tsx
+++ b/src/pages/Planner/components/GoalBox/goalList.tsx
@@ -1,10 +1,8 @@
 import GoalCard from '../GoalCard';
-import RecurringGoalsTable from '../RecurringGoalsTable';
 import { Box, Divider } from '@mui/material';
 import { GoalWiseInvestmentSuggestions } from '../../hooks/useInvestmentCalculator';
 import { FinancialGoal } from '../../../../domain/FinancialGoals';
 import { PlannerDataAction } from '../../../../store/plannerDataReducer';
-import { GoalType } from '../../../../types/enums';
 import { Dispatch } from 'react';
 
 type GoalListProps = {
@@ -18,58 +16,37 @@ const GoalList = ({
   goals,
   dispatch,
 }: GoalListProps) => {
-  // Separate recurring goals from one-time goals
-  const recurringGoals = goals.filter(
-    (goal) => goal.goalType === GoalType.RECURRING,
-  );
-  const oneTimeGoals = goals.filter(
-    (goal) => goal.goalType === GoalType.ONE_TIME,
-  );
-
   return (
-    <Box>
-      {/* Recurring Goals Table */}
-      {recurringGoals.length > 0 && (
-        <RecurringGoalsTable
-          recurringGoals={recurringGoals}
-          dispatch={dispatch}
-        />
-      )}
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        '& .divider': {
+          display: 'block',
+        },
+        '& .divider:last-child': {
+          display: 'none',
+        },
+      }}
+    >
+      {goals.map((goal: FinancialGoal) => {
+        const investmentBreakdown = investmentBreakdownForAllGoals.find(
+          (ib) => ib.goalName === goal.getGoalName(),
+        );
 
-      {/* One-time Goals Cards */}
-      {oneTimeGoals.length > 0 && (
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 2,
-            '& .divider': {
-              display: 'block',
-            },
-            '& .divider:last-child': {
-              display: 'none',
-            },
-          }}
-        >
-          {oneTimeGoals.map((goal: FinancialGoal) => {
-            const investmentBreakdown = investmentBreakdownForAllGoals.find(
-              (ib) => ib.goalName === goal.getGoalName(),
-            );
-
-            return (
-              <div key={goal.id}>
-                <GoalCard
-                  goal={goal}
-                  dispatch={dispatch}
-                  currentValue={investmentBreakdown?.currentValue!}
-                  investmentSuggestions={investmentBreakdown?.investmentSuggestions}
-                />
-                <Divider className="divider" />
-              </div>
-            );
-          })}
-        </Box>
-      )}
+        return (
+          <div key={goal.id}>
+            <GoalCard
+              goal={goal}
+              dispatch={dispatch}
+              currentValue={investmentBreakdown?.currentValue!}
+              investmentSuggestions={investmentBreakdown?.investmentSuggestions}
+            />
+            <Divider className="divider" />
+          </div>
+        );
+      })}
     </Box>
   );
 };

--- a/src/pages/Planner/components/GoalBox/index.test.tsx
+++ b/src/pages/Planner/components/GoalBox/index.test.tsx
@@ -1,0 +1,223 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import GoalBox from './index';
+import { FinancialGoal } from '../../../../domain/FinancialGoals';
+import { GoalType } from '../../../../types/enums';
+
+// Mock child components to keep tests focused on GoalBox tab behavior
+jest.mock('./goalList', () => {
+  return function MockGoalList({ goals }: { goals: FinancialGoal[] }) {
+    return (
+      <div data-testid="goal-list">
+        {goals.map((g) => (
+          <div key={g.id} data-testid={`goal-${g.goalName}`}>
+            {g.goalName}
+          </div>
+        ))}
+      </div>
+    );
+  };
+});
+
+describe('GoalBox', () => {
+  const mockDispatch = jest.fn();
+
+  const futureDate = '2099-12-31';
+  const pastDate = '2020-01-01';
+  const selectedDate = '2026-02-22';
+
+  const pendingGoal = new FinancialGoal(
+    'House Fund',
+    GoalType.ONE_TIME,
+    '2024-01-01',
+    futureDate,
+    5000000,
+  );
+
+  const completedGoal = new FinancialGoal(
+    'Car Fund',
+    GoalType.ONE_TIME,
+    '2019-01-01',
+    pastDate,
+    800000,
+  );
+
+  const recurringGoal = new FinancialGoal(
+    'Monthly Savings',
+    GoalType.RECURRING,
+    '2024-01-01',
+    futureDate,
+    120000,
+  );
+
+  const defaultProps = {
+    investmentBreakdownForAllGoals: [],
+    selectedDate,
+    dispatch: mockDispatch,
+    useStyledBox: false,
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Tab rendering', () => {
+    it('should render "One Time" and "Recurring" tabs', () => {
+      render(
+        <GoalBox
+          {...defaultProps}
+          financialGoals={[pendingGoal, recurringGoal]}
+        />,
+      );
+
+      expect(screen.getByRole('tab', { name: /One Time/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Recurring/i })).toBeInTheDocument();
+    });
+
+    it('should show goal counts in tab labels', () => {
+      render(
+        <GoalBox
+          {...defaultProps}
+          financialGoals={[pendingGoal, completedGoal, recurringGoal]}
+        />,
+      );
+
+      expect(screen.getByRole('tab', { name: 'One Time (2)' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Recurring (1)' })).toBeInTheDocument();
+    });
+
+    it('should default to the "One Time" tab on load', () => {
+      render(
+        <GoalBox
+          {...defaultProps}
+          financialGoals={[pendingGoal, recurringGoal]}
+        />,
+      );
+
+      const oneTimeTab = screen.getByRole('tab', { name: /One Time/i });
+      expect(oneTimeTab).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('One Time tab content', () => {
+    it('should show pending goals under "Financial Goals" heading', () => {
+      render(
+        <GoalBox
+          {...defaultProps}
+          financialGoals={[pendingGoal]}
+        />,
+      );
+
+      expect(screen.getByText('Financial Goals')).toBeInTheDocument();
+      expect(screen.getByTestId('goal-House Fund')).toBeInTheDocument();
+    });
+
+    it('should show completed goals under "Completed Goals" heading', () => {
+      render(
+        <GoalBox
+          {...defaultProps}
+          financialGoals={[completedGoal]}
+        />,
+      );
+
+      expect(screen.getByText('Completed Goals')).toBeInTheDocument();
+      expect(screen.getByTestId('goal-Car Fund')).toBeInTheDocument();
+    });
+
+    it('should show empty state when no one-time goals exist', () => {
+      render(
+        <GoalBox
+          {...defaultProps}
+          financialGoals={[recurringGoal]}
+        />,
+      );
+
+      expect(screen.getByText('No one-time goals added yet.')).toBeInTheDocument();
+    });
+  });
+
+  describe('Recurring tab content', () => {
+    it('should show recurring goals when Recurring tab is clicked', () => {
+      render(
+        <GoalBox
+          {...defaultProps}
+          financialGoals={[pendingGoal, recurringGoal]}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('tab', { name: /Recurring/i }));
+
+      expect(screen.getByTestId('goal-Monthly Savings')).toBeInTheDocument();
+    });
+
+    it('should hide one-time goals when Recurring tab is active', () => {
+      render(
+        <GoalBox
+          {...defaultProps}
+          financialGoals={[pendingGoal, recurringGoal]}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('tab', { name: /Recurring/i }));
+
+      expect(screen.queryByText('Financial Goals')).not.toBeVisible();
+    });
+
+    it('should show empty state when no recurring goals exist', () => {
+      render(
+        <GoalBox
+          {...defaultProps}
+          financialGoals={[pendingGoal]}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('tab', { name: /Recurring/i }));
+
+      expect(screen.getByText('No recurring goals added yet.')).toBeInTheDocument();
+    });
+  });
+
+  describe('Tab switching', () => {
+    it('should switch content when tabs are clicked', () => {
+      render(
+        <GoalBox
+          {...defaultProps}
+          financialGoals={[pendingGoal, recurringGoal]}
+        />,
+      );
+
+      // Default: One Time tab active
+      expect(screen.getByRole('tab', { name: /One Time/i })).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
+
+      // Click Recurring tab
+      fireEvent.click(screen.getByRole('tab', { name: /Recurring/i }));
+
+      expect(screen.getByRole('tab', { name: /Recurring/i })).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
+      expect(screen.getByRole('tab', { name: /One Time/i })).toHaveAttribute(
+        'aria-selected',
+        'false',
+      );
+    });
+  });
+
+  describe('Empty goals', () => {
+    it('should render tabs even when no goals exist at all', () => {
+      render(
+        <GoalBox
+          {...defaultProps}
+          financialGoals={[]}
+        />,
+      );
+
+      expect(screen.getByRole('tab', { name: 'One Time (0)' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Recurring (0)' })).toBeInTheDocument();
+      expect(screen.getByText('No one-time goals added yet.')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/Planner/components/GoalBox/index.tsx
+++ b/src/pages/Planner/components/GoalBox/index.tsx
@@ -1,7 +1,7 @@
-import { Grid2 as Grid, Typography } from '@mui/material';
+import { Box, Tab, Tabs, Typography } from '@mui/material';
 import { FinancialGoal } from '../../../../domain/FinancialGoals';
 import dayjs from 'dayjs';
-import { Dispatch, useMemo } from 'react';
+import { Dispatch, useMemo, useState } from 'react';
 import { PlannerDataAction } from '../../../../store/plannerDataReducer';
 import { GoalWiseInvestmentSuggestions } from '../../hooks/useInvestmentCalculator';
 import { StyledBox } from '../../../../components/StyledBox';
@@ -15,6 +15,7 @@ type GoalBoxProps = {
   dispatch: Dispatch<PlannerDataAction>;
   useStyledBox: boolean;
 };
+
 const GoalBox = ({
   financialGoals,
   selectedDate,
@@ -22,6 +23,8 @@ const GoalBox = ({
   dispatch,
   useStyledBox,
 }: GoalBoxProps) => {
+  const [activeTab, setActiveTab] = useState<0 | 1>(0);
+
   const sortedGoals = useMemo(
     () =>
       [...financialGoals].sort((goal1, goal2) => {
@@ -62,85 +65,76 @@ const GoalBox = ({
     [sortedGoals],
   );
 
-  function getPendingGoals() {
-    return (
-      <>
-        <Typography variant="h6" fontWeight="bold">
-          Financial Goals
-        </Typography>
-        <GoalList
-          investmentBreakdownForAllGoals={investmentBreakdownForAllGoals}
-          goals={pendingGoals}
-          dispatch={dispatch}
-        />
-      </>
-    );
-  }
+  const oneTimeCount = pendingGoals.length + completedGoals.length;
+  const recurringCount = recurringGoals.length;
 
-  function getCompletedGoals() {
-    return (
-      <>
-        <Typography variant="h6" fontWeight="bold">
-          Completed Goals
-        </Typography>
-        <GoalList
-          investmentBreakdownForAllGoals={investmentBreakdownForAllGoals}
-          goals={completedGoals}
-          dispatch={dispatch}
-        ></GoalList>
-      </>
-    );
-  }
+  const content = (
+    <Box>
+      <Tabs
+        value={activeTab}
+        onChange={(_, v) => setActiveTab(v as 0 | 1)}
+        sx={{ mb: 2 }}
+      >
+        <Tab label={`One Time (${oneTimeCount})`} />
+        <Tab label={`Recurring (${recurringCount})`} />
+      </Tabs>
 
-  function getRecurringGoals() {
-    return (
-      <>
-        <Typography variant="h6" fontWeight="bold">
-          Recurring Goals
-        </Typography>
-        <GoalList
-          investmentBreakdownForAllGoals={investmentBreakdownForAllGoals}
-          goals={recurringGoals}
-          dispatch={dispatch}
-        ></GoalList>
-      </>
-    );
-  }
+      <Box role="tabpanel" hidden={activeTab !== 0}>
+        {oneTimeCount === 0 ? (
+          <Typography variant="body2" sx={{ color: 'text.secondary', py: 2 }}>
+            No one-time goals added yet.
+          </Typography>
+        ) : (
+          <>
+            {pendingGoals.length > 0 && (
+              <>
+                <Typography variant="h6" fontWeight="bold">
+                  Financial Goals
+                </Typography>
+                <GoalList
+                  investmentBreakdownForAllGoals={investmentBreakdownForAllGoals}
+                  goals={pendingGoals}
+                  dispatch={dispatch}
+                />
+              </>
+            )}
+            {completedGoals.length > 0 && (
+              <>
+                <Typography variant="h6" fontWeight="bold" sx={{ mt: 2 }}>
+                  Completed Goals
+                </Typography>
+                <GoalList
+                  investmentBreakdownForAllGoals={investmentBreakdownForAllGoals}
+                  goals={completedGoals}
+                  dispatch={dispatch}
+                />
+              </>
+            )}
+          </>
+        )}
+      </Box>
 
-  return (
-    <Grid container>
-      {pendingGoals.length > 0 ? (
-        <Grid size={12} sx={{ mb: 2 }}>
-          {useStyledBox ? (
-            <StyledBox className="financial-goals-box">
-              {getPendingGoals()}
-            </StyledBox>
-          ) : (
-            getPendingGoals()
-          )}
-        </Grid>
-      ) : null}
+      <Box role="tabpanel" hidden={activeTab !== 1}>
+        {recurringCount === 0 ? (
+          <Typography variant="body2" sx={{ color: 'text.secondary', py: 2 }}>
+            No recurring goals added yet.
+          </Typography>
+        ) : (
+          <GoalList
+            investmentBreakdownForAllGoals={investmentBreakdownForAllGoals}
+            goals={recurringGoals}
+            dispatch={dispatch}
+          />
+        )}
+      </Box>
+    </Box>
+  );
 
-      {completedGoals.length > 0 ? (
-        <Grid size={12}>
-          {useStyledBox ? (
-            <StyledBox>{getCompletedGoals()}</StyledBox>
-          ) : (
-            getCompletedGoals()
-          )}
-        </Grid>
-      ) : null}
-
-      {recurringGoals.length > 0 ? (
-        <Grid size={12} sx={{ mt: 2 }}>
-          {useStyledBox ? (
-            <StyledBox>{getRecurringGoals()}</StyledBox>
-          ) : (
-            getRecurringGoals()
-          )}
-        </Grid>
-      ) : null}
-    </Grid>
+  return useStyledBox ? (
+    <StyledBox className="financial-goals-box">{content}</StyledBox>
+  ) : (
+    content
   );
 };
+
 export default GoalBox;

--- a/src/pages/Planner/components/InvestmentSuggestions/index.test.tsx
+++ b/src/pages/Planner/components/InvestmentSuggestions/index.test.tsx
@@ -38,18 +38,18 @@ jest.mock('../CustomLegend', () => {
 describe('InvestmentSuggestionsBox', () => {
   const mockDispatch = jest.fn();
   const mockInvestmentAllocations: InvestmentAllocationsType = {
-    [TermType.SHORT_TERM]: {
-      'High Yield Savings': 50,
-      'Liquid Funds': 50,
-    },
-    [TermType.MID_TERM]: {
-      'Short Duration Funds': 40,
-      'Corporate Bonds': 60,
-    },
-    [TermType.LONG_TERM]: {
-      'Index Funds': 60,
-      'Equity Mutual Funds': 40,
-    },
+    [TermType.SHORT_TERM]: [
+      { investmentName: 'High Yield Savings', investmentPercentage: 50, expectedReturnPercentage: 5 },
+      { investmentName: 'Liquid Funds', investmentPercentage: 50, expectedReturnPercentage: 6 },
+    ],
+    [TermType.MEDIUM_TERM]: [
+      { investmentName: 'Short Duration Funds', investmentPercentage: 40, expectedReturnPercentage: 7 },
+      { investmentName: 'Corporate Bonds', investmentPercentage: 60, expectedReturnPercentage: 8 },
+    ],
+    [TermType.LONG_TERM]: [
+      { investmentName: 'Index Funds', investmentPercentage: 60, expectedReturnPercentage: 12 },
+      { investmentName: 'Equity Mutual Funds', investmentPercentage: 40, expectedReturnPercentage: 14 },
+    ],
   };
 
   const mockInvestmentBreakdown = [

--- a/src/pages/Planner/components/RecurringGoalsTable/__snapshots__/index.test.tsx.snap
+++ b/src/pages/Planner/components/RecurringGoalsTable/__snapshots__/index.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`RecurringGoalsTable should match snapshot 1`] = `
               class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeMedium css-1sipjqd-MuiTableCell-root"
               scope="col"
             >
-              Monthly Target
+              Yearly Target
             </th>
             <th
               class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeMedium css-774dy1-MuiTableCell-root"

--- a/src/pages/Planner/components/RecurringGoalsTable/index.test.tsx
+++ b/src/pages/Planner/components/RecurringGoalsTable/index.test.tsx
@@ -53,7 +53,7 @@ describe('RecurringGoalsTable', () => {
     );
 
     expect(screen.getByText('Goal Name')).toBeInTheDocument();
-    expect(screen.getByText('Monthly Target')).toBeInTheDocument();
+    expect(screen.getByText('Yearly Target')).toBeInTheDocument();
     expect(screen.getByText('Actions')).toBeInTheDocument();
     expect(screen.getByText('Monthly Savings')).toBeInTheDocument();
     expect(screen.getByText('Investment SIP')).toBeInTheDocument();

--- a/src/pages/Planner/components/RecurringGoalsTable/index.tsx
+++ b/src/pages/Planner/components/RecurringGoalsTable/index.tsx
@@ -39,7 +39,7 @@ const RecurringGoalsTable = memo(
             <TableRow>
               <TableCell sx={{ fontWeight: 'bold' }}>Goal Name</TableCell>
               <TableCell align="right" sx={{ fontWeight: 'bold' }}>
-                Monthly Target
+                Yearly Target
               </TableCell>
               <TableCell align="center" sx={{ fontWeight: 'bold' }}>
                 Actions

--- a/src/pages/Planner/hooks/useInvestmentCalculator.ts
+++ b/src/pages/Planner/hooks/useInvestmentCalculator.ts
@@ -6,6 +6,7 @@ import {
   calculateCurrentPortfolioValue,
 } from '../../../domain/investmentCalculations';
 import { InvestmentSuggestion } from '../../../types/planner';
+import { GoalType } from '../../../types/enums';
 
 export type GoalWiseInvestmentSuggestions = {
   goalName: string;
@@ -44,9 +45,10 @@ const useInvestmentCalculator = (plannerData: PlannerData) => {
 
       return {
         goalName: goal.getGoalName(),
-        investmentSuggestions: isGoalActive(goal, selectedDate)
-          ? investmentSuggestions
-          : [],
+        investmentSuggestions:
+          goal.goalType === GoalType.RECURRING || isGoalActive(goal, selectedDate)
+            ? investmentSuggestions
+            : [],
         currentValue,
       };
     });


### PR DESCRIPTION
- Added MUI Tabs to replace the stacked layout in GoalBox, allowing users to switch between "One Time" and "Recurring" goals.
- Updated GoalBox to manage tab state and display counts for each goal type.
- Refactored GoalList to remove internal goal type filtering, simplifying rendering logic.
- Corrected label from "Monthly Target" to "Yearly Target" in RecurringGoalsTable for accurate representation of data.
- Enhanced empty state handling for both tabs, displaying appropriate messages when no goals are present.
- Created tests for GoalBox to ensure tab functionality and correct rendering of goals.
- Cleaned up imports and unused code to maintain clarity and performance.