### PR TITLE
feat: locale-aware currency display and recurring goal duration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # goal-based-financial-planner Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-03-19
+Auto-generated from all feature plans. Last updated: 2026-04-11
 
 ## Active Technologies
 - TypeScript (React 18, CRA / react-scripts 5) + MUI v6 (`@mui/material` — Tabs, Tab already available), React 18 hooks (004-goals-tabbed-view)
@@ -11,6 +11,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-19
 - Browser `localStorage` via `src/util/storage.ts` — no change (006-upgrade-dependencies)
 - TypeScript 4.x, React 19.2.4, Vite 8.0.0 + @mui/material v6, react-hook-form, dayjs, `idb-keyval` (new — ~300B brotli), Google Identity Services (CDN script) (007-flexible-storage-provider)
 - File System Access API + IndexedDB (local); Google Drive REST API + appDataFolder scope (cloud); sessionStorage (Drive file ID only) (007-flexible-storage-provider)
+- TypeScript 4.x + React 19.2.4, Vite 8.0.0, MUI v6, react-hook-form, dayjs (009-locale-currency-goal-duration)
+- File System Access API + IndexedDB (local); Google Drive REST API (cloud) (009-locale-currency-goal-duration)
 
 - Markdown / N/A (documentation only) + N/A (static documentation files) (003-oss-documentation)
 
@@ -31,9 +33,9 @@ tests/
 Markdown / N/A (documentation only): Follow standard conventions
 
 ## Recent Changes
+- 009-locale-currency-goal-duration: Added TypeScript 4.x + React 19.2.4, Vite 8.0.0, MUI v6, react-hook-form, dayjs
 - 007-flexible-storage-provider: Added TypeScript 4.x, React 19.2.4, Vite 8.0.0 + @mui/material v6, react-hook-form, dayjs, `idb-keyval` (new — ~300B brotli), Google Identity Services (CDN script)
 - 006-upgrade-dependencies: Added TypeScript 4.x (unchanged); React 18.3.1 → 19.2.4 + Vite 8.0.0, @vitejs/plugin-react, Vitest (replaces react-scripts 5.0.1 / Jest 27)
-- 005-investment-tracking: Added TypeScript 4.x (React 18, CRA / react-scripts 5) + MUI v6 (`@mui/material`, `@mui/x-date-pickers` already present), `react-hook-form` (already present), `dayjs` (already present)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/009-locale-currency-goal-duration/checklists/requirements.md
+++ b/specs/009-locale-currency-goal-duration/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Locale Currency Formatting and Recurring Goal Duration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- Two independent user stories: locale currency display (P1) and recurring goal duration (P2) — each deployable independently.
+- Backward compatibility assumption for existing recurring goals is documented in the Assumptions section.

--- a/specs/009-locale-currency-goal-duration/data-model.md
+++ b/specs/009-locale-currency-goal-duration/data-model.md
@@ -1,0 +1,137 @@
+# Data Model: Locale Currency Formatting and Recurring Goal Duration
+
+**Feature**: 009-locale-currency-goal-duration  
+**Date**: 2026-04-11
+
+---
+
+## Changed Entity: FinancialGoal
+
+**File**: `src/domain/FinancialGoals.ts`
+
+### Field Changes
+
+| Field | Before | After | Notes |
+|-------|--------|-------|-------|
+| `recurringDurationYears` | _(absent)_ | `number \| undefined` | Optional. Only meaningful when `goalType === RECURRING`. Valid range: 1–3. Defaults to `1` when absent (backward compat). |
+
+### Constructor Signature Change
+
+```ts
+// Before
+constructor(
+  goalName: string,
+  goalType: GoalType,
+  startDate: string,
+  targetDate: string,
+  targetAmount: number,
+)
+
+// After
+constructor(
+  goalName: string,
+  goalType: GoalType,
+  startDate: string,
+  targetDate: string,
+  targetAmount: number,
+  recurringDurationYears?: number,   // NEW — optional, valid 1–3
+)
+```
+
+### Method Behavior Changes
+
+| Method | Before | After |
+|--------|--------|-------|
+| `getTerm()` | Returns `1` for RECURRING | Returns `this.recurringDurationYears ?? 1` for RECURRING |
+| `getMonthTerm()` | Returns `12` for RECURRING | Returns `(this.recurringDurationYears ?? 1) * 12` for RECURRING |
+| `getTermType()` | RECURRING always SHORT_TERM (via hardcoded 12-month term) | Still SHORT_TERM — all valid durations (12–36 months) fall within the ≤36 month SHORT_TERM threshold |
+| `getInflationAdjustedTargetAmount()` | Returns `targetAmount` unchanged for RECURRING | Unchanged — no inflation adjustment for recurring goals |
+
+### Derived Display Value (Not Stored)
+
+The **yearly target** shown in `RecurringGoalsTable` is a display-only derivation:
+
+```
+yearlyTargetDisplay = goal.getTargetAmount() / (goal.recurringDurationYears ?? 1)
+```
+
+This is computed in the component, not persisted as a field.
+
+### Validation Rules (enforced in FinancialGoalForm)
+
+| Field | Rule |
+|-------|------|
+| `recurringDurationYears` | Required for RECURRING goals. Must be a whole integer. Must satisfy `1 ≤ value ≤ 3`. |
+
+---
+
+## Changed Utility: formatCompactCurrency
+
+**File**: `src/types/util.ts`
+
+### New Function
+
+```ts
+/**
+ * Formats a number as a compact currency string for chart axis labels.
+ * Uses locale-appropriate magnitude suffixes:
+ * - INR: ₹10.5Cr (crore), ₹3.5L (lakh)
+ * - Others: $10.5M (million), $3.5K (thousand)
+ *
+ * Falls back to formatCurrency for values below threshold.
+ */
+export const formatCompactCurrency = (num: number): string
+```
+
+### Behavior by Locale
+
+| Locale/Currency | >= 10,000,000 | >= 100,000 | >= 1,000 | < 1,000 |
+|-----------------|---------------|------------|----------|---------|
+| INR (en-IN, hi-IN) | `₹10.5Cr` | `₹3.5L` | — | `formatCurrency(num, 'INR')` |
+| USD (en-US) | — | — | `$3.5K` | `formatCurrency(num, 'USD')` |
+| USD (en-US) | `$10.5M` | — | `$3.5K` | `formatCurrency(num, 'USD')` |
+| EUR (de-DE, fr-FR) | `€10.5M` | — | `€3.5K` | `formatCurrency(num, 'EUR')` |
+| GBP (en-GB) | `£10.5M` | — | `£3.5K` | `formatCurrency(num, 'GBP')` |
+
+---
+
+## Storage Serialization
+
+### Stored JSON Shape (after this feature)
+
+```json
+{
+  "financialGoals": [
+    {
+      "id": "...",
+      "goalName": "Vacation",
+      "goalType": "Recurring",
+      "startDate": "",
+      "targetDate": "",
+      "targetAmount": 120000,
+      "recurringDurationYears": 2
+    }
+  ]
+}
+```
+
+### Backward Compatibility
+
+Old files without `recurringDurationYears` are loaded safely:
+- `g.recurringDurationYears` will be `undefined`
+- Constructor receives `undefined`, sets `this.recurringDurationYears = undefined`
+- `getTerm()` / `getMonthTerm()` use `?? 1` fallback → behavior identical to pre-feature
+
+---
+
+## Files Requiring No Data Model Changes
+
+The following files change only their **display layer** (replacing `₹{formatNumber()}` with `formatCurrency()` or `formatCompactCurrency()`), with no data model impact:
+
+- `GoalCard/index.tsx`
+- `GoalCard/InvestmentTracker/index.tsx`
+- `GoalCard/InvestmentLogHistory/index.tsx`
+- `GoalCard/LogEntryForm/index.tsx`
+- `TermwiseProgressBox/index.tsx`
+- `CustomLegend/index.tsx`
+- `CongratulationsPage/index.tsx`

--- a/specs/009-locale-currency-goal-duration/plan.md
+++ b/specs/009-locale-currency-goal-duration/plan.md
@@ -1,0 +1,85 @@
+# Implementation Plan: Locale Currency Formatting and Recurring Goal Duration
+
+**Branch**: `009-locale-currency-goal-duration` | **Date**: 2026-04-11 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `/specs/009-locale-currency-goal-duration/spec.md`
+
+## Summary
+
+Replace all hardcoded `₹` currency prefixes throughout the UI with locale-aware formatting that detects the user's browser locale and applies the correct currency symbol, number grouping, and compact notation. Add a `recurringDurationYears` field (1–3) to recurring financial goals, exposing it through the goal form and driving SIP calculations from the full-duration total.
+
+## Technical Context
+
+**Language/Version**: TypeScript 4.x  
+**Primary Dependencies**: React 19.2.4, Vite 8.0.0, MUI v6, react-hook-form, dayjs  
+**Storage**: File System Access API + IndexedDB (local); Google Drive REST API (cloud)  
+**Testing**: Vitest  
+**Target Platform**: Modern browser (desktop + mobile web)  
+**Project Type**: Single-page web application  
+**Performance Goals**: No new latency concerns; `Intl.NumberFormat` is synchronous  
+**Constraints**: No backend; all data persisted client-side  
+**Scale/Scope**: ~12 UI files touched; 2 domain class changes; 2 storage provider changes
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Clear Layering | PASS | `formatCompactCurrency` stays in `src/types/util.ts`; `recurringDurationYears` field and term derivation live in `src/domain/FinancialGoals.ts`. No business logic leaks into UI components. |
+| II. Feature Co-location | PASS | Duration input confined to `FinancialGoalForm` under its page; recurring table updated in its own component. Shared formatter added to existing shared util file. |
+| III. Upgrade-Friendly Boundaries | PASS | No new 3rd-party dependencies introduced. `Intl.NumberFormat` is a browser built-in. |
+| IV. Type Safety | PASS | `recurringDurationYears` typed as `number | undefined` on `FinancialGoal`; no `any` introduced. |
+| V. Predictable Change | PASS | New `formatCompactCurrency` unit-tested in `src/types/util.test.tsx`; SIP calculation changes tested in `src/domain/FinancialGoals.test.ts`. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-locale-currency-goal-duration/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── quickstart.md        ← Phase 1 output
+└── tasks.md             ← Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (files modified by this feature)
+
+```text
+src/
+├── types/
+│   └── util.ts                               ← add formatCompactCurrency()
+├── domain/
+│   └── FinancialGoals.ts                     ← add recurringDurationYears field + update getTerm/getMonthTerm
+├── pages/
+│   ├── Home/
+│   │   └── components/
+│   │       └── FinancialGoalForm/
+│   │           └── index.tsx                 ← add duration input for recurring goals
+│   ├── Planner/
+│   │   └── components/
+│   │       ├── GoalCard/
+│   │       │   ├── index.tsx                 ← ₹ → formatCurrency
+│   │       │   └── components/
+│   │       │       ├── InvestmentTracker/
+│   │       │       │   └── index.tsx         ← Y-axis + inline ₹ → formatCompactCurrency/formatCurrency
+│   │       │       ├── InvestmentLogHistory/
+│   │       │       │   └── index.tsx         ← ₹ → formatCurrency
+│   │       │       └── LogEntryForm/
+│   │       │           └── index.tsx         ← label "Monthly SIP Amount (₹)" → locale-aware
+│   │       ├── RecurringGoalsTable/
+│   │       │   └── index.tsx                 ← ₹ → formatCurrency; add Duration column; derive yearly target
+│   │       ├── TermwiseProgressBox/
+│   │       │   └── index.tsx                 ← ₹ → formatCurrency
+│   │       └── CustomLegend/
+│   │           └── index.tsx                 ← formatNumber → formatCurrency
+│   └── CongratulationsPage/
+│       └── index.tsx                         ← formatNumber → formatCurrency
+└── util/
+    └── storage/
+        ├── localFileProvider.ts              ← pass recurringDurationYears to FinancialGoal constructor
+        └── googleDriveProvider.ts            ← pass recurringDurationYears to FinancialGoal constructor
+```
+
+**Structure Decision**: Single frontend app; no backend. All changes confined to `src/`. No new files needed — this feature modifies existing files only.

--- a/specs/009-locale-currency-goal-duration/quickstart.md
+++ b/specs/009-locale-currency-goal-duration/quickstart.md
@@ -1,0 +1,85 @@
+# Quickstart: Locale Currency Formatting and Recurring Goal Duration
+
+**Feature**: 009-locale-currency-goal-duration  
+**Date**: 2026-04-11
+
+---
+
+## How to test Feature 1: Locale Currency
+
+To test locale-aware currency display without changing your OS settings, open your browser's developer tools and override the locale:
+
+**Chrome DevTools:**
+1. Open DevTools → three-dot menu → More tools → Sensors
+2. Set "Locale override" to `en-US`, `de-DE`, `hi-IN`, etc.
+3. Refresh the app — all currency amounts should update to the locale's format.
+
+Alternatively, use the `getUserLocale` / `setUserLocale` functions directly in the console:
+
+```js
+// Simulate US locale
+localStorage.setItem('preferred_locale', 'en-US');
+location.reload();
+
+// Simulate Indian locale
+localStorage.setItem('preferred_locale', 'en-IN');
+location.reload();
+
+// Clear override (revert to browser default)
+localStorage.removeItem('preferred_locale');
+```
+
+---
+
+## How to test Feature 2: Recurring Goal Duration
+
+1. Start the dev server: `npm run dev` (or `npm start`)
+2. Open the app and navigate to the goal planner.
+3. Click "Add Goal" and select **Recurring** goal type.
+4. A new **Duration** field (1–3 years) should appear below the goal type selector.
+5. Enter a target amount (e.g., 120000) and duration of 2.
+6. Save the goal and navigate to the Planner view.
+7. The recurring goals table should show:
+   - **Duration**: 2 years
+   - **Yearly Target**: 60,000 (120,000 ÷ 2)
+8. The monthly SIP suggestion should be: 5,000/mo (120,000 ÷ 24 months)
+
+**Validation tests:**
+- Enter duration `0` → form should show error, goal should not save
+- Enter duration `4` → form should show error
+- Enter duration `1.5` → form should show error (non-integer)
+- Leave duration blank → form should show error
+
+---
+
+## Run Tests
+
+```bash
+# Run all tests
+npm test
+
+# Run specific test suites relevant to this feature
+npx vitest run src/types/util.test.tsx
+npx vitest run src/domain/FinancialGoals.test.ts
+npx vitest run src/pages/Planner/components/RecurringGoalsTable
+```
+
+---
+
+## Key Files at a Glance
+
+| File | What changed |
+|------|-------------|
+| `src/types/util.ts` | + `formatCompactCurrency()` |
+| `src/domain/FinancialGoals.ts` | + `recurringDurationYears` field; updated `getTerm`/`getMonthTerm` |
+| `src/pages/Home/components/FinancialGoalForm/index.tsx` | + duration input for recurring goals |
+| `src/pages/Planner/components/RecurringGoalsTable/index.tsx` | + Duration column; derived yearly target |
+| `src/util/storage/localFileProvider.ts` | Pass `recurringDurationYears` on deserialization |
+| `src/util/storage/googleDriveProvider.ts` | Pass `recurringDurationYears` on deserialization |
+| `src/pages/Planner/components/GoalCard/index.tsx` | ₹ → `formatCurrency` |
+| `src/pages/Planner/components/GoalCard/components/InvestmentTracker/index.tsx` | Y-axis + amounts → `formatCompactCurrency` / `formatCurrency` |
+| `src/pages/Planner/components/GoalCard/components/InvestmentLogHistory/index.tsx` | ₹ → `formatCurrency` |
+| `src/pages/Planner/components/GoalCard/components/LogEntryForm/index.tsx` | Label ₹ → locale currency symbol |
+| `src/pages/Planner/components/TermwiseProgressBox/index.tsx` | ₹ → `formatCurrency` |
+| `src/pages/Planner/components/CustomLegend/index.tsx` | `formatNumber` → `formatCurrency` |
+| `src/pages/CongratulationsPage/index.tsx` | `formatNumber` → `formatCurrency` |

--- a/specs/009-locale-currency-goal-duration/research.md
+++ b/specs/009-locale-currency-goal-duration/research.md
@@ -1,0 +1,103 @@
+# Research: Locale Currency Formatting and Recurring Goal Duration
+
+**Feature**: 009-locale-currency-goal-duration  
+**Date**: 2026-04-11
+
+---
+
+## Topic 1: Locale-Aware Currency Formatting
+
+### Decision
+Use `Intl.NumberFormat` (via the existing `formatCurrency` and `formatNumber` utilities in `src/types/util.ts`) for all monetary display. Introduce a new `formatCompactCurrency` helper for chart axis/tooltip abbreviated notation that uses locale to determine both currency symbol and magnitude suffix.
+
+### Rationale
+- `formatCurrency` already exists and is locale-aware (detects browser locale via `getUserLocale()`).
+- The only gap is: (a) many components still use the hardcoded `₹` prefix with `formatNumber`, and (b) there is no compact formatter for chart Y-axes.
+- `Intl.NumberFormat` with `notation: 'compact'` produces locale-appropriate compact output but does not use INR-specific abbreviations like Cr/L. For INR, custom thresholds (10M = 1Cr, 100K = 1L) are needed. For other locales, M/K are standard.
+- No new library dependency needed — this is pure browser built-in behavior.
+
+### Compact Formatter Design
+```
+formatCompactCurrency(v, locale, currency):
+  if currency === 'INR':
+    v >= 10_000_000 → `₹${(v/10_000_000).toFixed(1)}Cr`
+    v >= 100_000    → `₹${(v/100_000).toFixed(1)}L`
+    else            → formatCurrency(v, 'INR')
+  else (USD, GBP, EUR, JPY, etc.):
+    v >= 1_000_000  → `${symbol}${(v/1_000_000).toFixed(1)}M`
+    v >= 1_000      → `${symbol}${(v/1_000).toFixed(1)}K`
+    else            → formatCurrency(v, currency)
+```
+Currency symbol for non-INR locales is extracted from a small one-char format call: `(0).toLocaleString(locale, {style:'currency', currency, maximumFractionDigits:0}).replace(/[\d,.\s]/g,'').trim()`.
+
+### Alternatives Considered
+- `Intl.NumberFormat notation: 'compact'`: Produces "10M" without currency symbol; requires extra concatenation and doesn't produce Cr/L for INR.
+- Chart-level number-only display: Would drop currency context from axes — confusing for multi-goal planners.
+
+---
+
+## Topic 2: Locale-to-Currency Mapping Completeness
+
+### Decision
+Extend the existing `localeCurrencyMap` in `formatCurrency` to cover the locales already in `AVAILABLE_LOCALES` (en-IN, hi-IN, en-US, en-GB, de-DE, fr-FR, ja-JP). All unmapped locales fall through to USD default — consistent with clarification Q1.
+
+### Rationale
+The existing map already covers the primary locales. No extension needed for the initial feature; the map is centralized and easy to extend later.
+
+---
+
+## Topic 3: Recurring Goal Duration — Domain Model
+
+### Decision
+Add an optional `recurringDurationYears?: number` property to `FinancialGoal`. Default to `1` everywhere it is absent (for backward compatibility). Thread through constructor as the 6th optional parameter.
+
+**Updated calculations:**
+- `getTerm()` for RECURRING: `this.recurringDurationYears ?? 1`
+- `getMonthTerm()` for RECURRING: `(this.recurringDurationYears ?? 1) * 12`
+- Term classification: RECURRING goals always remain SHORT_TERM (clarification Q3 answer: B).
+
+**SIP math impact:**
+- `calculateTotalMonthlySIP` receives `getMonthTerm()` as the horizon.
+- With `recurringDurationYears = 2`, `getMonthTerm() = 24`. The SIP calculator spreads the total target over 24 months.
+- The RecurringGoalsTable "Yearly Target" column shows `goal.getTargetAmount() / (goal.recurringDurationYears ?? 1)` — a derived display value, not a stored field.
+
+### Rationale
+- Minimal surface change: one new optional field, two updated methods.
+- `??` null-coalescing preserves backward compat for goals saved without the field.
+- No data migration required: the field is optional; old stored JSON simply won't have it.
+
+### Alternatives Considered
+- Storing `recurringDurationMonths`: Rejected — years is the user-visible unit; derived months internally is straightforward.
+- Storing a derived `yearlyTarget` field: Rejected — derived state should not be persisted; always compute from `targetAmount ÷ duration`.
+
+---
+
+## Topic 4: Storage Backward Compatibility
+
+### Decision
+Update `_parsePlannerData` in both `localFileProvider.ts` and `googleDriveProvider.ts` to pass `g.recurringDurationYears` as the 6th argument to the `FinancialGoal` constructor.
+
+```ts
+new FinancialGoal(
+  g.goalName, g.goalType, g.startDate, g.targetDate,
+  g.targetAmount,
+  g.recurringDurationYears,  // undefined for old data → defaults to 1
+)
+```
+
+No schema version bump needed. `undefined` flows through to the `?? 1` default in the domain class.
+
+### Rationale
+The storage layer re-hydrates plain JSON objects into class instances. Adding `g.recurringDurationYears` (which will be `undefined` for pre-existing files) is safe because the domain class defaults to 1 when the value is absent.
+
+---
+
+## Topic 5: Form Validation for Duration
+
+### Decision
+Use a simple controlled `TextField` (type="number") with `inputProps={{ min: 1, max: 3 }}` plus explicit validation in the `handleAdd` function (matching the existing pattern for `targetAmount`). The field is only shown when `goalType === GoalType.RECURRING`.
+
+### Rationale
+- Consistent with the existing form validation pattern (no library change needed).
+- Integer validation: check `Number.isInteger(parsed) && parsed >= 1 && parsed <= 3`.
+- Pre-filling with `1` as default keeps the field usable without mandatory entry — the user only needs to change it if not 1 year.

--- a/specs/009-locale-currency-goal-duration/spec.md
+++ b/specs/009-locale-currency-goal-duration/spec.md
@@ -1,0 +1,102 @@
+# Feature Specification: Locale Currency Formatting and Recurring Goal Duration
+
+**Feature Branch**: `009-locale-currency-goal-duration`  
+**Created**: 2026-04-11  
+**Status**: Draft  
+**Input**: User description: "I want to add few miscellaneous features. 1. I want to show currently based on the locale of the user. Everywhere where there is currently, the comma separation and the symbol should match the locale. 2. I want to add duration for recurring goals, this duration should be in years and should not be more than 3 years."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Locale-Aware Currency Display (Priority: P1)
+
+A user from India opens the financial planner and sees all monetary values displayed with the Indian Rupee symbol (₹) and Indian number formatting (e.g., ₹10,00,000). A user from the United States sees the same amounts displayed in US Dollar format (e.g., $1,000,000). A user from Germany sees amounts with Euro symbol and German number separators (e.g., 1.000.000 €). The currency symbol, decimal separator, and thousands separator all adapt automatically to match the user's locale — without any manual configuration needed.
+
+**Why this priority**: Currency display is a fundamental aspect of the financial planning experience. Showing the wrong currency symbol or number format creates confusion and erodes trust. This affects every monetary value shown throughout the application.
+
+**Independent Test**: Can be fully tested by opening the application in a browser configured with different regional locale settings and verifying that all monetary amounts — goal targets, investment suggestions, monthly SIP values, yearly recurring totals, progress amounts — display with the correct currency symbol and number grouping for that locale.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user whose device/browser is set to the Indian locale, **When** they view any monetary amount in the application, **Then** the amount is shown with the ₹ symbol and Indian number formatting (e.g., ₹10,00,000)
+2. **Given** a user whose device/browser is set to the US locale, **When** they view any monetary amount, **Then** the amount is shown with the $ symbol and US formatting (e.g., $1,000,000)
+3. **Given** a user whose device/browser is set to a European locale (e.g., Germany), **When** they view any monetary amount, **Then** the amount is shown with the € symbol and locale-appropriate separators
+4. **Given** a user whose locale maps to an unrecognized or unsupported region, **When** they view monetary amounts, **Then** amounts are displayed with a sensible default (USD) without any error or missing symbol
+5. **Given** any monetary value displayed in a form field label (e.g., "Monthly SIP Amount"), **When** the user views that label, **Then** the currency symbol in the label matches the user's locale
+
+---
+
+### User Story 2 - Recurring Goal Duration Input (Priority: P2)
+
+A user creates a recurring financial goal (e.g., monthly household expenses, annual vacation budget). When adding this recurring goal, they can specify how many years this goal will recur — between 1 and 3 years. Once saved, the planner uses this duration to compute accurate investment planning recommendations and projections over the specified period rather than assuming a fixed 1-year duration.
+
+**Why this priority**: Without a duration, all recurring goals are treated as 1-year commitments, which produces inaccurate investment suggestions for goals that span multiple years. Duration directly impacts financial calculations and the usefulness of the planner's recommendations.
+
+**Independent Test**: Can be fully tested by creating a recurring goal with durations of 1, 2, and 3 years and verifying that the investment calculations and goal display reflect the chosen duration. Can also be tested in isolation from Feature 1 using any currency display.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is creating a recurring goal, **When** they fill in the goal form, **Then** a duration field is visible allowing them to enter a value in years (1–3)
+2. **Given** a user creates a recurring goal with a target of $24,000 and duration of 2 years, **When** they save and view the planner, **Then** the monthly SIP suggestion is $1,000 ($24,000 ÷ 24 months) and the displayed yearly target is $12,000
+3. **Given** a user attempts to enter a duration greater than 3 years, **When** the form validates, **Then** an error is shown and the goal cannot be saved until duration is within the 1–3 year range
+4. **Given** a user enters a duration of 0 or a non-positive number, **When** the form validates, **Then** an error is shown requiring a valid positive duration
+5. **Given** an existing recurring goal saved before this feature, **When** it is loaded, **Then** it defaults to 1-year duration and continues to behave as before (backward compatibility)
+6. **Given** a user views the recurring goals table on the Planner page, **When** the goal is displayed, **Then** the duration (e.g., "2 years") is shown alongside the goal name and yearly target
+
+---
+
+### Edge Cases
+
+- What happens when a user's locale is a region not in the known locale-to-currency mapping? (Default to USD display)
+- What happens when the browser does not expose a language/locale setting? (Default to USD display)
+- What happens when a recurring goal's duration is left blank? (Treat as a validation error; goal cannot be saved)
+- How does the planner handle fractional or decimal input for duration (e.g., 1.5 years)? (Only whole-year values are accepted; decimals are rejected)
+- What happens to the recurring goals table display for goals that already exist with no stored duration? (They default to 1 year gracefully)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: All monetary values displayed throughout the application MUST use the currency symbol appropriate for the user's locale (e.g., ₹ for India, $ for US, € for Germany)
+- **FR-001a**: Chart axis labels and tooltips that use abbreviated notation MUST adapt to locale-appropriate compact suffixes (e.g., INR: ₹10.5Cr / ₹3.5L; USD: $10.5M / $3.5K; EUR: €10.5M / €3.5K)
+- **FR-002**: All monetary values MUST use the number grouping and decimal separator conventions of the user's locale (e.g., Indian lakh/crore grouping, US thousands grouping, European period-as-thousands-separator)
+- **FR-003**: Locale detection MUST be automatic, based on the user's browser/device regional settings, without requiring the user to manually select a currency or region
+- **FR-004**: When the user's locale maps to an unrecognized region or currency, the system MUST fall back to displaying amounts in USD with US formatting
+- **FR-005**: Currency symbols in form field labels (e.g., "Monthly SIP Amount (₹)") MUST also reflect the user's locale
+- **FR-006**: The recurring goal creation form MUST include a duration field that accepts whole-number values from 1 to 3 (inclusive), labeled clearly as years
+- **FR-007**: The system MUST reject recurring goal submissions where the duration is outside the 1–3 year range, displaying a clear validation error to the user
+- **FR-008**: The target amount of a recurring goal represents the total amount to be achieved over the full duration; the system MUST calculate monthly SIP as target amount ÷ (duration in years × 12)
+- **FR-008a**: The yearly target displayed in the recurring goals table MUST be derived as target amount ÷ duration years (not entered directly by the user)
+- **FR-009**: Recurring goals with no stored duration (created before this feature) MUST be treated as having a 1-year duration to maintain backward compatibility
+- **FR-010**: The recurring goals table on the Planner page MUST display the duration alongside each goal's name and yearly target amount
+
+### Key Entities
+
+- **Recurring Goal**: A financial goal that repeats over time; now extended with a duration (in whole years, 1–3) specifying how long the goal recurs
+- **Locale**: The user's regional language/country setting as detected from the browser; determines currency symbol and number format used throughout the application
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of monetary values displayed in the application show the correct currency symbol and number format matching the user's locale, with zero hardcoded currency symbols remaining in the UI
+- **SC-002**: Users with non-USD locales (e.g., India, Germany, UK) see correctly formatted amounts without any manual configuration steps
+- **SC-003**: A recurring goal with a 3-year duration produces investment recommendations visibly different from a 1-year goal of the same target amount, demonstrating that duration is factored into calculations
+- **SC-004**: The recurring goal form prevents saving goals with invalid durations (0, >3, or non-integer) and presents a clear error message, with a 100% error capture rate for out-of-range values
+- **SC-005**: All previously created recurring goals (with no stored duration) continue to load and display without errors after the feature is deployed
+
+## Clarifications
+
+### Session 2026-04-11
+
+- Q: For chart/graph axis labels and tooltips using abbreviated Indian notation (e.g., ₹10.5Cr, ₹3.5L), how should non-INR locales display these? → A: Use locale-appropriate compact notation (e.g., $10.5M, $3.5K for USD; locale-equivalent suffixes for others)
+- Q: When a recurring goal has a multi-year duration, what does the target amount represent and how is SIP derived? → A: The target amount is the total to achieve over the full duration; monthly SIP = target amount ÷ (duration × 12); displayed yearly target is derived as target amount ÷ duration years
+- Q: Should a recurring goal's term classification (short/medium/long) be derived from its duration or stay fixed? → A: Recurring goals always remain fixed as Short Term regardless of duration
+
+## Assumptions
+
+- The user's locale is determined entirely by the browser's language/region setting; there is no in-app locale selector as part of this feature
+- Duration is entered as a whole number (integer years); fractional years are not supported
+- The maximum duration of 3 years for recurring goals is a hard business rule, not adjustable by the user
+- Locale-to-currency mapping covers at minimum: India (INR), United States (USD), United Kingdom (GBP), Germany/France/EU (EUR), Japan (JPY); all other locales fall back to USD
+- Backward compatibility for existing recurring goals assumes stored data will not have a duration field; the application gracefully defaults to 1 year in this case
+- Recurring goals are always classified as Short Term regardless of duration; term classification is not derived from the duration field

--- a/specs/009-locale-currency-goal-duration/tasks.md
+++ b/specs/009-locale-currency-goal-duration/tasks.md
@@ -1,0 +1,173 @@
+# Tasks: Locale Currency Formatting and Recurring Goal Duration
+
+**Input**: Design documents from `/specs/009-locale-currency-goal-duration/`  
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, quickstart.md ✓
+
+**Tests**: Unit tests included for new utility function and updated domain logic (core calculation changes require test coverage per Constitution Principle V).
+
+**Organization**: Tasks grouped by user story. US1 and US2 are fully independent — they touch different files except `RecurringGoalsTable` (assigned to US2 since it's primarily a data change with a display fix bundled in).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify environment is ready. No new dependencies or files to create.
+
+- [x] T001 Confirm dev environment is working — run `npm install && npm test` from repo root
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisite)
+
+**Purpose**: Add the shared `formatCompactCurrency` utility needed by US1's chart axis formatter. US2 has no foundational dependencies.
+
+**⚠️ CRITICAL**: T009 (InvestmentTracker chart) cannot start until this phase is complete.
+
+- [x] T002 Add `formatCompactCurrency(num: number): string` to `src/types/util.ts` — uses `getUserLocale()` and `localeCurrencyMap` to produce INR compact (Cr/L) or generic compact (M/K) with locale currency symbol; falls back to `formatCurrency` below threshold (see data-model.md §formatCompactCurrency for full logic)
+- [x] T003 [P] Add unit tests for `formatCompactCurrency` in `src/types/util.test.tsx` — cover INR (Cr, L, below-threshold), USD (M, K, below-threshold), EUR, and unknown-locale fallback to USD
+
+**Checkpoint**: `formatCompactCurrency` exported and tested — T009 can now proceed.
+
+---
+
+## Phase 3: User Story 1 — Locale-Aware Currency Display (Priority: P1) 🎯 MVP
+
+**Goal**: Replace all hardcoded `₹` prefixes with locale-aware currency formatting so users on any locale see the correct symbol and number grouping.
+
+**Independent Test**: Set `localStorage.setItem('preferred_locale', 'en-US')`, reload the app, and verify every monetary value in the UI shows `$` with US number grouping. Repeat with `en-IN` to verify `₹` with Indian grouping.
+
+### Implementation for User Story 1
+
+- [x] T004 [P] [US1] Replace `₹{formatNumber(termTypeSum)}` with `formatCurrency(termTypeSum)` in `src/pages/Planner/components/TermwiseProgressBox/index.tsx` — update import from `formatNumber` to `formatCurrency`
+- [x] T005 [P] [US1] Replace `₹{formatNumber(goal.getTargetAmount())}` with `formatCurrency(goal.getTargetAmount())` in `src/pages/Planner/components/RecurringGoalsTable/index.tsx` — update import (note: Duration column and yearly target derivation handled in T015)
+- [x] T006 [P] [US1] Replace `₹{formatNumber(totalMonthlyInvestment)}` (line 170) and `₹{formatNumber(suggestion.amount)}` (line 241) with `formatCurrency(...)` calls in `src/pages/Planner/components/GoalCard/index.tsx` — update import
+- [x] T007 [P] [US1] Replace `₹${formatNumber(groupTotal)}/mo` and `₹{formatNumber(sip.monthlyAmount)}/mo` with `${formatCurrency(groupTotal)}/mo` and `${formatCurrency(sip.monthlyAmount)}/mo` in `src/pages/Planner/components/GoalCard/components/InvestmentLogHistory/index.tsx`
+- [x] T008 [P] [US1] Update `label="Monthly SIP Amount (₹)"` in `src/pages/Planner/components/GoalCard/components/LogEntryForm/index.tsx` — derive currency symbol from `getUserLocale()` using the locale-to-currency map; import `getUserLocale` from `src/types/util`
+- [x] T009 [US1] Replace Y-axis `valueFormatter` (lines 92–97) with `formatCompactCurrency` and replace three inline `₹{formatNumber(...)}` amount labels (lines 166, 169, 178) with `formatCurrency(...)` in `src/pages/Planner/components/GoalCard/components/InvestmentTracker/index.tsx` — depends on T002
+- [x] T010 [P] [US1] Replace `{formatNumber(Math.round(value))}` with `{formatCurrency(Math.round(value))}` in `src/pages/Planner/components/CustomLegend/index.tsx` — update import
+- [x] T011 [P] [US1] Replace `{formatNumber(targetAmount)}` (line 58) and `{formatNumber(goal.amount)}` (line 77) with `{formatCurrency(...)}` in `src/pages/CongratulationsPage/index.tsx` — update import
+
+**Checkpoint**: US1 fully functional. Set browser locale to `en-US`, verify all monetary values in the UI show `$` with correct grouping. US2 can begin independently.
+
+---
+
+## Phase 4: User Story 2 — Recurring Goal Duration (Priority: P2)
+
+**Goal**: Add a 1–3 year duration field to recurring goals, use it in SIP calculations (total target ÷ duration months), and display it in the recurring goals table.
+
+**Independent Test**: Create a recurring goal with target `120000` and duration `2`. In the planner, verify the recurring goals table shows "Yearly Target: 60,000" and "Duration: 2 years". Verify the monthly SIP suggestion for that goal is `5,000/mo` (120,000 ÷ 24).
+
+### Implementation for User Story 2
+
+- [x] T012 [US2] Add optional `recurringDurationYears?: number` field to `FinancialGoal` class in `src/domain/FinancialGoals.ts` — update constructor to accept 6th optional param; update `getTerm()` to return `this.recurringDurationYears ?? 1` for RECURRING; update `getMonthTerm()` to return `(this.recurringDurationYears ?? 1) * 12` for RECURRING (see data-model.md for full spec)
+- [x] T013 [P] [US2] Update `_parsePlannerData` in `src/util/storage/localFileProvider.ts` — pass `g.recurringDurationYears` as 6th arg to `FinancialGoal` constructor (undefined for old data → defaults to 1 automatically)
+- [x] T014 [P] [US2] Update `_parsePlannerData` in `src/util/storage/googleDriveProvider.ts` — same change as T013: pass `g.recurringDurationYears` as 6th arg to `FinancialGoal` constructor
+- [x] T015 [US2] Add duration TextField (type number, default `1`, min `1`, max `3`) to `src/pages/Home/components/FinancialGoalForm/index.tsx` — show only when `goalType === GoalType.RECURRING`; add `recurringDurationYears` state (default `'1'`); validate integer in [1,3] in `handleAdd`; pass parsed value to `FinancialGoal` constructor as 6th arg; reset to `'1'` in `resetForm()` — depends on T012
+- [x] T016 [US2] Add "Duration" column and derive yearly target in `src/pages/Planner/components/RecurringGoalsTable/index.tsx` — add "Duration" `TableCell` header; display `${goal.recurringDurationYears ?? 1} year${(goal.recurringDurationYears ?? 1) > 1 ? 's' : ''}` per row; change "Yearly Target" column to display `formatCurrency(goal.getTargetAmount() / (goal.recurringDurationYears ?? 1))` — depends on T012; also removes remaining `₹` hardcode (subsumes T005 for this file)
+- [x] T017 [P] [US2] Update `src/domain/FinancialGoals.test.ts` — add tests: `getTerm()` returns `recurringDurationYears` when set; `getMonthTerm()` returns `duration × 12`; `recurringDurationYears = undefined` defaults to 1 for both; non-RECURRING goals unaffected — depends on T012
+
+**Checkpoint**: US2 fully functional. Create 1-year and 2-year recurring goals and verify SIP calculations differ correctly.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Clean up snapshot files broken by display changes and validate full build.
+
+- [x] T018 [P] Update snapshot files broken by currency display changes — delete or regenerate `src/pages/Planner/components/RecurringGoalsTable/__snapshots__/index.test.tsx.snap`, `src/pages/CongratulationsPage/__snapshots__/index.test.tsx.snap`, and any other affected `__snapshots__` directories by running `npx vitest run --update-snapshots`
+- [x] T019 Run `npm run build` from repo root and confirm no TypeScript errors or build failures
+- [x] T020 [P] Run `npm test` (full suite) and confirm all tests pass
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — blocks T009 only
+- **US1 (Phase 3)**: T004–T008, T010–T011 can start after Phase 1; T009 requires T002
+- **US2 (Phase 4)**: Fully independent of US1 — can proceed in parallel with Phase 3 after Phase 1; T015 and T016 depend on T012 within the phase
+- **Polish (Phase 5)**: Depends on Phase 3 and Phase 4 completion
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Independent — requires only `formatCompactCurrency` from Phase 2 (T002) for T009; all other US1 tasks use existing `formatCurrency`
+- **User Story 2 (P2)**: Independent of US1 — domain change (T012) is the only internal prerequisite for T015 and T016; storage updates (T013, T014) are parallel to T012
+
+### Within Each User Story
+
+- US1: T004–T008, T010–T011 are all parallel; T009 waits for T002
+- US2: T012 first; then T013, T014, T017 in parallel; then T015, T016
+
+### Parallel Opportunities
+
+Tasks marked `[P]` operate on distinct files with no shared write conflicts. Within US1, seven of eight tasks are parallel. Within US2, T013/T014/T017 are parallel after T012.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# These 7 tasks can all run simultaneously (different files):
+T004 – TermwiseProgressBox/index.tsx
+T005 – RecurringGoalsTable/index.tsx (currency fix only)
+T006 – GoalCard/index.tsx
+T007 – GoalCard/InvestmentLogHistory/index.tsx
+T008 – GoalCard/LogEntryForm/index.tsx
+T010 – CustomLegend/index.tsx
+T011 – CongratulationsPage/index.tsx
+
+# T009 runs after T002 completes:
+T009 – GoalCard/InvestmentTracker/index.tsx
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# T012 first:
+T012 – FinancialGoals.ts (domain change)
+
+# Then in parallel:
+T013 – localFileProvider.ts
+T014 – googleDriveProvider.ts
+T017 – FinancialGoals.test.ts
+
+# Then in parallel (both depend on T012):
+T015 – FinancialGoalForm/index.tsx
+T016 – RecurringGoalsTable/index.tsx
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Verify environment
+2. Complete Phase 2: Add `formatCompactCurrency` + tests
+3. Complete Phase 3: Replace all hardcoded `₹` across 8 UI files
+4. **STOP and VALIDATE**: Set locale to `en-US`, confirm all amounts show `$`
+5. Ship US1 independently if desired
+
+### Incremental Delivery
+
+1. Phase 1 + 2: Foundation ready
+2. Phase 3 (US1): Locale currency everywhere → validate → demo
+3. Phase 4 (US2): Recurring duration → validate → demo
+4. Phase 5: Polish, snapshots, build gate
+
+---
+
+## Notes
+
+- `[P]` tasks operate on different files and have no shared write conflicts
+- US1 and US2 are fully independent — a single developer can work them sequentially, or two developers in parallel
+- T005 and T016 both touch `RecurringGoalsTable/index.tsx`: if working sequentially, T005 can be skipped and the `₹` fix bundled into T016; if working in parallel, T005 does the currency fix and T016 adds the Duration column
+- Snapshot files (`__snapshots__/`) should be regenerated last (T018) once all component changes are settled
+- Constitution gate: run `npm run build` (T019) and `npm test` (T020) before marking feature complete

--- a/src/domain/FinancialGoals.test.ts
+++ b/src/domain/FinancialGoals.test.ts
@@ -28,7 +28,7 @@ describe('FinancialGoal', () => {
       expect(goal.getMonthTerm()).toBe(24);
     });
 
-    it('should return 1 year term for recurring goals', () => {
+    it('should return 1 year term for recurring goals with no duration set', () => {
       const goal = new FinancialGoal(
         'Annual Vacation',
         GoalType.RECURRING,
@@ -40,7 +40,7 @@ describe('FinancialGoal', () => {
       expect(goal.getTerm()).toBe(1);
     });
 
-    it('should return 12 month term for recurring goals', () => {
+    it('should return 12 month term for recurring goals with no duration set', () => {
       const goal = new FinancialGoal(
         'Annual Vacation',
         GoalType.RECURRING,
@@ -50,6 +50,36 @@ describe('FinancialGoal', () => {
       );
 
       expect(goal.getMonthTerm()).toBe(12);
+    });
+
+    it('should return recurringDurationYears as the term for recurring goals', () => {
+      const goal2 = new FinancialGoal('Expenses', GoalType.RECURRING, '', '', 120000, 2);
+      const goal3 = new FinancialGoal('Expenses', GoalType.RECURRING, '', '', 120000, 3);
+
+      expect(goal2.getTerm()).toBe(2);
+      expect(goal3.getTerm()).toBe(3);
+    });
+
+    it('should return recurringDurationYears * 12 as month term for recurring goals', () => {
+      const goal2 = new FinancialGoal('Expenses', GoalType.RECURRING, '', '', 120000, 2);
+      const goal3 = new FinancialGoal('Expenses', GoalType.RECURRING, '', '', 120000, 3);
+
+      expect(goal2.getMonthTerm()).toBe(24);
+      expect(goal3.getMonthTerm()).toBe(36);
+    });
+
+    it('should default to 1 year / 12 months when recurringDurationYears is undefined', () => {
+      const goal = new FinancialGoal('Legacy', GoalType.RECURRING, '', '', 60000, undefined);
+
+      expect(goal.getTerm()).toBe(1);
+      expect(goal.getMonthTerm()).toBe(12);
+    });
+
+    it('should not affect term calculation for one-time goals regardless of recurringDurationYears', () => {
+      const goal = new FinancialGoal('Car', GoalType.ONE_TIME, '2024-01-01', '2026-01-01', 500000, 2);
+
+      expect(goal.getTerm()).toBe(2); // dayjs diff, not duration
+      expect(goal.getMonthTerm()).toBe(24);
     });
 
     it('should classify goals as SHORT_TERM (≤36 months)', () => {

--- a/src/domain/FinancialGoals.ts
+++ b/src/domain/FinancialGoals.ts
@@ -15,6 +15,7 @@ export class FinancialGoal {
     startDate: string,
     targetDate: string,
     targetAmount: number,
+    recurringDurationYears?: number,
   ) {
     this.id = crypto.randomUUID();
     this.goalName = goalName;
@@ -22,6 +23,7 @@ export class FinancialGoal {
     this.startDate = startDate;
     this.targetDate = targetDate;
     this.targetAmount = targetAmount;
+    this.recurringDurationYears = recurringDurationYears;
   }
 
   id: string;
@@ -30,6 +32,8 @@ export class FinancialGoal {
   startDate: string;
   targetDate: string;
   targetAmount: number;
+  /** Duration in years for recurring goals. Valid range: 1–3. Undefined for one-time goals and legacy recurring goals (defaults to 1). */
+  recurringDurationYears?: number;
 
   getInvestmentStartDate(): string {
     // If the goal is recurring, we don't have a specific start date. Return today's date
@@ -53,14 +57,14 @@ export class FinancialGoal {
 
   getTerm(): number {
     if (this.goalType === GoalType.RECURRING) {
-      return 1;
+      return this.recurringDurationYears ?? 1;
     }
     return dayjs(this.targetDate).diff(dayjs(this.startDate), 'year');
   }
 
   getMonthTerm(): number {
     if (this.goalType === GoalType.RECURRING) {
-      return 12;
+      return (this.recurringDurationYears ?? 1) * 12;
     }
     return dayjs(this.targetDate).diff(dayjs(this.startDate), 'month');
   }

--- a/src/pages/CongratulationsPage/__snapshots__/index.test.tsx.snap
+++ b/src/pages/CongratulationsPage/__snapshots__/index.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`CongratulationsPage > should match snapshot of congratulations content 
           <h2
             class="MuiTypography-root MuiTypography-h2 css-1jxdnlo-MuiTypography-root"
           >
-            5,000,000
+            $5,000,000
           </h2>
         </div>
         <div
@@ -65,7 +65,7 @@ exports[`CongratulationsPage > should match snapshot of congratulations content 
               </span>
                -
                
-              5,000,000
+              $5,000,000
             </p>
             <p
               class="MuiTypography-root MuiTypography-body1 css-e0r9tj-MuiTypography-root"
@@ -77,7 +77,7 @@ exports[`CongratulationsPage > should match snapshot of congratulations content 
               </span>
                -
                
-              2,000,000
+              $2,000,000
             </p>
             <p
               class="MuiTypography-root MuiTypography-body1 css-e0r9tj-MuiTypography-root"
@@ -89,7 +89,7 @@ exports[`CongratulationsPage > should match snapshot of congratulations content 
               </span>
                -
                
-              1,000,000
+              $1,000,000
             </p>
           </div>
         </div>

--- a/src/pages/CongratulationsPage/index.test.tsx
+++ b/src/pages/CongratulationsPage/index.test.tsx
@@ -12,9 +12,10 @@ vi.mock('react-confetti', () => ({
 // Mock react-use/lib/useWindowSize hook
 vi.mock('react-use/lib/useWindowSize', () => ({ default: () => ({ width: 1920, height: 1080 }) }));
 
-// Mock formatNumber for deterministic snapshots
+// Mock format utilities for deterministic snapshots
 vi.mock('../../types/util', () => ({
   formatNumber: (num: number) => num.toLocaleString('en-US'),
+  formatCurrency: (num: number) => `$${num.toLocaleString('en-US')}`,
 }));
 
 describe('CongratulationsPage', () => {
@@ -51,7 +52,8 @@ describe('CongratulationsPage', () => {
     );
 
     expect(screen.getByText(/Your Total Savings/i)).toBeInTheDocument();
-    expect(screen.getByText('8,000,000')).toBeInTheDocument();
+    // formatCurrency mock returns "$8,000,000"
+    expect(screen.getByText('$8,000,000')).toBeInTheDocument();
   });
 
   it('should render all goal details', () => {
@@ -97,6 +99,7 @@ describe('CongratulationsPage', () => {
     );
 
     expect(screen.getByText('Vacation')).toBeInTheDocument();
-    expect(screen.getByText('1,000,000')).toBeInTheDocument();
+    // formatCurrency mock returns "$1,000,000"
+    expect(screen.getByText('$1,000,000')).toBeInTheDocument();
   });
 });

--- a/src/pages/CongratulationsPage/index.tsx
+++ b/src/pages/CongratulationsPage/index.tsx
@@ -3,7 +3,7 @@ import { StyledBox } from '../../components/StyledBox';
 import Confetti from 'react-confetti';
 import useWindowSize from 'react-use/lib/useWindowSize';
 import { useState, useEffect } from 'react';
-import { formatNumber } from '../../types/util';
+import { formatCurrency } from '../../types/util';
 import { GoalSummary } from '../../types/goals';
 
 const CongratulationsPage = ({
@@ -55,7 +55,7 @@ const CongratulationsPage = ({
               sx={{ fontWeight: 'bold', mt: 2 }}
               color="primary"
             >
-              {formatNumber(targetAmount)}
+              {formatCurrency(targetAmount)}
             </Typography>
           </StyledBox>
           <StyledBox
@@ -74,7 +74,7 @@ const CongratulationsPage = ({
               {goals.map((goal) => (
                 <Typography key={goal.name} color="primary">
                   <span style={{ fontWeight: 'bold' }}>{goal.name}</span> -{' '}
-                  {formatNumber(goal.amount)}
+                  {formatCurrency(goal.amount)}
                 </Typography>
               ))}
             </Box>

--- a/src/pages/Home/components/FinancialGoalForm/index.tsx
+++ b/src/pages/Home/components/FinancialGoalForm/index.tsx
@@ -69,6 +69,7 @@ const FinancialGoalForm = ({
     setStartDate('');
     setTargetDate('');
     setTargetAmount('');
+    setRecurringDurationYears('1');
   };
 
   const [goalName, setGoalName] = useState<string>('');
@@ -76,6 +77,7 @@ const FinancialGoalForm = ({
   const [startDate, setStartDate] = useState<string>('');
   const [targetDate, setTargetDate] = useState<string>('');
   const [targetAmount, setTargetAmount] = useState<string>('');
+  const [recurringDurationYears, setRecurringDurationYears] = useState<string>('1');
   const [validationErrors, setValidationErrors] = useState<
     Record<string, boolean>
   >({});
@@ -134,6 +136,9 @@ const FinancialGoalForm = ({
       }
     }
 
+    const parsedDuration =
+      goalType === GoalType.RECURRING ? Number(recurringDurationYears) : undefined;
+
     if (Object.keys(errors).length > 0) {
       setValidationErrors(errors);
       return;
@@ -146,6 +151,7 @@ const FinancialGoalForm = ({
         startDate,
         targetDate,
         Number(targetAmount),
+        parsedDuration,
       ),
     );
 
@@ -234,6 +240,20 @@ const FinancialGoalForm = ({
                       />
                     </RadioGroup>
                   </FormControl>
+                  {goalType === GoalType.RECURRING && (
+                    <FormControl component="fieldset" sx={{ mt: 0.5 }}>
+                      <Typography variant="body2">Duration</Typography>
+                      <RadioGroup
+                        value={recurringDurationYears}
+                        onChange={(e) => setRecurringDurationYears(e.target.value)}
+                        row
+                      >
+                        <FormControlLabel value="1" control={<Radio size="small" />} label="1 year" />
+                        <FormControlLabel value="2" control={<Radio size="small" />} label="2 years" />
+                        <FormControlLabel value="3" control={<Radio size="small" />} label="3 years" />
+                      </RadioGroup>
+                    </FormControl>
+                  )}
                   {goalType === GoalType.ONE_TIME && (
                     <Box sx={{ display: 'flex', gap: 1, mt: 0.5 }}>
                       <DatePicker

--- a/src/pages/Planner/components/CustomLegend/__snapshots__/index.test.tsx.snap
+++ b/src/pages/Planner/components/CustomLegend/__snapshots__/index.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`CustomLegend > should match snapshot 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jlqdff-MuiTableCell-root"
           >
-            4,000,000
+            $4,000,000
           </td>
         </tr>
         <tr
@@ -50,7 +50,7 @@ exports[`CustomLegend > should match snapshot 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jlqdff-MuiTableCell-root"
           >
-            1,000,000
+            $1,000,000
           </td>
         </tr>
         <tr
@@ -71,7 +71,7 @@ exports[`CustomLegend > should match snapshot 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jlqdff-MuiTableCell-root"
           >
-            1,000,000
+            $1,000,000
           </td>
         </tr>
       </tbody>

--- a/src/pages/Planner/components/CustomLegend/index.test.tsx
+++ b/src/pages/Planner/components/CustomLegend/index.test.tsx
@@ -4,9 +4,10 @@ import CustomLegend from './index';
 import { GoalWiseInvestmentSuggestions } from '../../hooks/useInvestmentCalculator';
 import { useMediaQuery } from '@mui/material';
 
-// Mock formatNumber
+// Mock format utilities
 vi.mock('../../../../types/util', () => ({
   formatNumber: (num: number) => num.toLocaleString('en-US'),
+  formatCurrency: (num: number) => `$${num.toLocaleString('en-US')}`,
 }));
 
 // Mock useMediaQuery
@@ -55,8 +56,8 @@ describe('CustomLegend', () => {
 
   it('should aggregate amounts for same investment type', () => {
     render(<CustomLegend suggestions={mockSuggestions} />);
-    // Large Cap should be 3M + 1M = 4M
-    expect(screen.getByText('4,000,000')).toBeInTheDocument();
+    // Large Cap should be 3M + 1M = 4M; formatCurrency mock returns "$4,000,000"
+    expect(screen.getByText('$4,000,000')).toBeInTheDocument();
   });
 
   it('should handle empty suggestions', () => {

--- a/src/pages/Planner/components/CustomLegend/index.tsx
+++ b/src/pages/Planner/components/CustomLegend/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mui/material';
 
 import { GoalWiseInvestmentSuggestions } from '../../hooks/useInvestmentCalculator';
-import { formatNumber } from '../../../../types/util';
+import { formatCurrency } from '../../../../types/util';
 import { InvestmentAmountMap } from '../../../../types/charts';
 import { memo, useMemo } from 'react';
 
@@ -65,7 +65,7 @@ const CustomLegend = memo(
                   </TableCell>
                   <TableCell sx={{ padding: '4px 8px' }}>{key}</TableCell>
                   <TableCell sx={{ padding: '4px 8px', textAlign: 'right' }}>
-                    {formatNumber(Math.round(value))}
+                    {formatCurrency(Math.round(value))}
                   </TableCell>
                 </TableRow>
               );

--- a/src/pages/Planner/components/GoalCard/components/InvestmentLogHistory/index.tsx
+++ b/src/pages/Planner/components/GoalCard/components/InvestmentLogHistory/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Chip, IconButton, Typography } from '@mui/material';
 import { SIPEntry } from '../../../../../../types/investmentLog';
-import { formatNumber } from '../../../../../../types/util';
+import { formatCurrency } from '../../../../../../types/util';
 
 type Props = {
   sips: SIPEntry[];
@@ -41,7 +41,7 @@ const SIPList = ({ sips, onEdit, onDelete }: Props) => {
                 {type}
               </Typography>
               <Chip
-                label={`₹${formatNumber(groupTotal)}/mo`}
+                label={`${formatCurrency(groupTotal)}/mo`}
                 size="small"
                 sx={{ height: 18, fontSize: '0.65rem' }}
               />
@@ -65,7 +65,7 @@ const SIPList = ({ sips, onEdit, onDelete }: Props) => {
                   fontWeight="bold"
                   sx={{ mx: 1, whiteSpace: 'nowrap' }}
                 >
-                  ₹{formatNumber(sip.monthlyAmount)}/mo
+                  {formatCurrency(sip.monthlyAmount)}/mo
                 </Typography>
                 <IconButton
                   size="small"

--- a/src/pages/Planner/components/GoalCard/components/InvestmentTracker/index.tsx
+++ b/src/pages/Planner/components/GoalCard/components/InvestmentTracker/index.tsx
@@ -10,7 +10,7 @@ import {
   buildSIPComparison,
   buildGrowthProjection,
 } from '../../../../../../domain/investmentLog';
-import { formatNumber } from '../../../../../../types/util';
+import { formatCurrency, formatCompactCurrency } from '../../../../../../types/util';
 import SIPForm from '../LogEntryForm';
 import SIPList from '../InvestmentLogHistory';
 
@@ -89,12 +89,7 @@ const InvestmentTracker = ({
         xAxis={[{ data: xLabels, scaleType: 'point' as const }]}
         yAxis={[
           {
-            valueFormatter: (v: number) =>
-              v >= 10000000
-                ? `₹${(v / 10000000).toFixed(1)}Cr`
-                : v >= 100000
-                ? `₹${(v / 100000).toFixed(1)}L`
-                : `₹${formatNumber(v)}`,
+            valueFormatter: (v: number) => formatCompactCurrency(v),
           },
         ]}
         sx={{ '& .MuiChartsLegend-root': { fontSize: '0.7rem' } }}
@@ -163,10 +158,10 @@ const InvestmentTracker = ({
                     {/* Amount labels */}
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
                       <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>
-                        ₹{formatNumber(row.actualAmount)}/mo
+                        {formatCurrency(row.actualAmount)}/mo
                         {!isCustom && (
                           <Box component="span" sx={{ color: 'text.disabled' }}>
-                            {' '}/ ₹{formatNumber(row.suggestedAmount)}
+                            {' '}/ {formatCurrency(row.suggestedAmount)}
                           </Box>
                         )}
                       </Typography>
@@ -175,7 +170,7 @@ const InvestmentTracker = ({
                           variant="caption"
                           sx={{ fontSize: '0.65rem', color: isExceeding ? 'success.main' : 'error.main' }}
                         >
-                          {isExceeding ? '+' : ''}₹{formatNumber(row.difference)}/mo
+                          {isExceeding ? '+' : ''}{formatCurrency(row.difference)}/mo
                         </Typography>
                       )}
                     </Box>

--- a/src/pages/Planner/components/GoalCard/components/LogEntryForm/index.tsx
+++ b/src/pages/Planner/components/GoalCard/components/LogEntryForm/index.tsx
@@ -8,7 +8,8 @@ import {
   DialogTitle,
   TextField,
 } from '@mui/material';
-import { Dispatch, useEffect } from 'react';
+import { Dispatch, useEffect, useMemo } from 'react';
+import { getUserLocale } from '../../../../../../types/util';
 import { useForm, Controller, useWatch } from 'react-hook-form';
 import { PlannerDataAction } from '../../../../../../store/plannerDataReducer';
 import {
@@ -32,6 +33,11 @@ type Props = {
   existingEntry?: SIPEntry;
 };
 
+const localeCurrencyMap: Record<string, string> = {
+  'en-IN': 'INR', 'hi-IN': 'INR', 'en-US': 'USD',
+  'en-GB': 'GBP', 'de-DE': 'EUR', 'fr-FR': 'EUR', 'ja-JP': 'JPY',
+};
+
 const SIPForm = ({
   open,
   onClose,
@@ -40,6 +46,15 @@ const SIPForm = ({
   existingEntry,
 }: Props) => {
   const isEditMode = Boolean(existingEntry);
+
+  const currencySymbol = useMemo(() => {
+    const locale = getUserLocale();
+    const currency = localeCurrencyMap[locale] || 'USD';
+    return (0)
+      .toLocaleString(locale, { style: 'currency', currency, maximumFractionDigits: 0 })
+      .replace(/[\d,.\s]/g, '')
+      .trim();
+  }, []);
 
   const {
     register,
@@ -157,7 +172,7 @@ const SIPForm = ({
           )}
 
           <TextField
-            label="Monthly SIP Amount (₹)"
+            label={`Monthly SIP Amount (${currencySymbol})`}
             type="number"
             inputProps={{ min: 1, step: 1 }}
             error={Boolean(errors.monthlyAmount)}

--- a/src/pages/Planner/components/GoalCard/index.tsx
+++ b/src/pages/Planner/components/GoalCard/index.tsx
@@ -12,7 +12,7 @@ import dayjs from 'dayjs';
 import { GoalType } from '../../../../types/enums';
 import { useMemo, useState, Dispatch, memo, useCallback } from 'react';
 import { InvestmentSuggestion } from '../../../../types/planner';
-import { formatNumber } from '../../../../types/util';
+import { formatCurrency } from '../../../../types/util';
 import { PlannerDataAction } from '../../../../store/plannerDataReducer';
 
 const INVESTMENT_COLORS = [
@@ -51,11 +51,11 @@ const GoalCard = memo(
       [investmentSuggestions],
     );
 
-  const formattedTargetAmount = formatNumber(
+  const formattedTargetAmount = formatCurrency(
     goal.getInflationAdjustedTargetAmount(),
   );
 
-  const formattedCurrentValue = formatNumber(goal.getTargetAmount());
+  const formattedCurrentValue = formatCurrency(goal.getTargetAmount());
 
   const progressPercentage = Math.round(
     (currentValue / goal.getInflationAdjustedTargetAmount()) * 100,
@@ -167,7 +167,7 @@ const GoalCard = memo(
             >
               expand_more
             </span>
-            Monthly SIP: ₹{formatNumber(totalMonthlyInvestment)}
+            Monthly SIP: {formatCurrency(totalMonthlyInvestment)}
           </Typography>
 
           {/* Mini color bar preview when collapsed */}
@@ -238,7 +238,7 @@ const GoalCard = memo(
                       component="span"
                       sx={{ fontWeight: 'bold', ml: 0.5 }}
                     >
-                      ₹{formatNumber(suggestion.amount)}
+                      {formatCurrency(suggestion.amount)}
                     </Typography>
                   </Box>
                 }

--- a/src/pages/Planner/components/RecurringGoalsTable/__snapshots__/index.test.tsx.snap
+++ b/src/pages/Planner/components/RecurringGoalsTable/__snapshots__/index.test.tsx.snap
@@ -34,6 +34,12 @@ exports[`RecurringGoalsTable > should match snapshot 1`] = `
               class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeMedium css-774dy1-MuiTableCell-root"
               scope="col"
             >
+              Duration
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeMedium css-774dy1-MuiTableCell-root"
+              scope="col"
+            >
               Actions
             </th>
           </tr>
@@ -60,8 +66,18 @@ exports[`RecurringGoalsTable > should match snapshot 1`] = `
               <p
                 class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
               >
-                ₹
-                5,000
+                $5,000
+              </p>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeMedium css-14y13q2-MuiTableCell-root"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
+              >
+                1
+                 
+                year
               </p>
             </td>
             <td
@@ -99,8 +115,18 @@ exports[`RecurringGoalsTable > should match snapshot 1`] = `
               <p
                 class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
               >
-                ₹
-                10,000
+                $10,000
+              </p>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeMedium css-14y13q2-MuiTableCell-root"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
+              >
+                1
+                 
+                year
               </p>
             </td>
             <td

--- a/src/pages/Planner/components/RecurringGoalsTable/index.test.tsx
+++ b/src/pages/Planner/components/RecurringGoalsTable/index.test.tsx
@@ -8,9 +8,10 @@ import * as actions from '../../../../store/plannerDataActions';
 // Mock actions
 vi.mock('../../../../store/plannerDataActions');
 
-// Mock formatNumber
+// Mock format utilities
 vi.mock('../../../../types/util', () => ({
   formatNumber: (num: number) => num.toLocaleString('en-US'),
+  formatCurrency: (num: number) => `$${num.toLocaleString('en-US')}`,
 }));
 
 describe('RecurringGoalsTable', () => {
@@ -54,6 +55,7 @@ describe('RecurringGoalsTable', () => {
 
     expect(screen.getByText('Goal Name')).toBeInTheDocument();
     expect(screen.getByText('Yearly Target')).toBeInTheDocument();
+    expect(screen.getByText('Duration')).toBeInTheDocument();
     expect(screen.getByText('Actions')).toBeInTheDocument();
     expect(screen.getByText('Monthly Savings')).toBeInTheDocument();
     expect(screen.getByText('Investment SIP')).toBeInTheDocument();
@@ -67,8 +69,23 @@ describe('RecurringGoalsTable', () => {
       />,
     );
 
-    expect(screen.getByText('₹5,000')).toBeInTheDocument();
-    expect(screen.getByText('₹10,000')).toBeInTheDocument();
+    // Yearly target = targetAmount / duration (default 1 year)
+    expect(screen.getByText('$5,000')).toBeInTheDocument();
+    expect(screen.getByText('$10,000')).toBeInTheDocument();
+  });
+
+  it('should display duration in years', () => {
+    const goalWith2Years = new FinancialGoal('Trip', GoalType.RECURRING, '', '', 24000, 2);
+    render(
+      <RecurringGoalsTable
+        recurringGoals={[goalWith2Years]}
+        dispatch={mockDispatch}
+      />,
+    );
+
+    expect(screen.getByText('2 years')).toBeInTheDocument();
+    // Yearly target = 24000 / 2 = 12000
+    expect(screen.getByText('$12,000')).toBeInTheDocument();
   });
 
   it('should call deleteFinancialGoal when delete button clicked', () => {

--- a/src/pages/Planner/components/RecurringGoalsTable/index.tsx
+++ b/src/pages/Planner/components/RecurringGoalsTable/index.tsx
@@ -13,7 +13,7 @@ import {
 import { FinancialGoal } from '../../../../domain/FinancialGoals';
 import { PlannerDataAction } from '../../../../store/plannerDataReducer';
 import { deleteFinancialGoal } from '../../../../store/plannerDataActions';
-import { formatNumber } from '../../../../types/util';
+import { formatCurrency } from '../../../../types/util';
 import { Dispatch, memo } from 'react';
 
 type RecurringGoalsTableProps = {
@@ -42,12 +42,16 @@ const RecurringGoalsTable = memo(
                 Yearly Target
               </TableCell>
               <TableCell align="center" sx={{ fontWeight: 'bold' }}>
+                Duration
+              </TableCell>
+              <TableCell align="center" sx={{ fontWeight: 'bold' }}>
                 Actions
               </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {recurringGoals.map((goal) => {
+              const duration = goal.recurringDurationYears ?? 1;
               return (
                 <TableRow
                   key={goal.id}
@@ -67,7 +71,12 @@ const RecurringGoalsTable = memo(
                   </TableCell>
                   <TableCell align="right">
                     <Typography variant="body1">
-                      ₹{formatNumber(goal.getTargetAmount())}
+                      {formatCurrency(goal.getTargetAmount() / duration)}
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="center">
+                    <Typography variant="body1">
+                      {duration} {duration === 1 ? 'year' : 'years'}
                     </Typography>
                   </TableCell>
                   <TableCell align="center">

--- a/src/pages/Planner/components/TermwiseProgressBox/index.test.tsx
+++ b/src/pages/Planner/components/TermwiseProgressBox/index.test.tsx
@@ -172,8 +172,8 @@ describe('TermWiseProgressBox', () => {
 
     render(<TermWiseProgressBox data={data} />);
 
-    // The formatNumber function should format this as "₹1,000,000"
-    expect(screen.getByText('₹1,000,000')).toBeInTheDocument();
+    // formatCurrency uses locale-aware formatting; in en-US test env this renders as "$1,000,000"
+    expect(screen.getByText('$1,000,000')).toBeInTheDocument();
   });
 
   it('should render with single term type data', () => {

--- a/src/pages/Planner/components/TermwiseProgressBox/index.tsx
+++ b/src/pages/Planner/components/TermwiseProgressBox/index.tsx
@@ -1,7 +1,7 @@
 import { Box, Typography, Chip, Grid2 as Grid, Tooltip } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { StyledBox } from '../../../../components/StyledBox';
-import { formatNumber } from '../../../../types/util';
+import { formatCurrency } from '../../../../types/util';
 import { TermTypeWiseProgressData, TermTypeWiseData } from '../../../../types/planner';
 import { memo } from 'react';
 
@@ -61,7 +61,7 @@ const TermSection = ({
       {/* Amount + goal count */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
         <Typography variant="body1" fontWeight={600}>
-          ₹{formatNumber(termTypeSum)}
+          {formatCurrency(termTypeSum)}
         </Typography>
         <Typography variant="body2" color="text.secondary">
           {goalNames.length} goal{goalNames.length !== 1 ? 's' : ''}

--- a/src/types/util.test.tsx
+++ b/src/types/util.test.tsx
@@ -4,6 +4,7 @@ import {
   clearUserLocale,
   formatNumber,
   formatCurrency,
+  formatCompactCurrency,
   formatIndianNumber,
   formatIndianCurrency,
   AVAILABLE_LOCALES,
@@ -13,6 +14,8 @@ import { renderHook } from '@testing-library/react';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 describe('Locale and Formatting Utilities', () => {
+  let originalIntl: typeof Intl;
+
   beforeEach(() => {
     localStorage.clear();
     // Reset navigator.language to default
@@ -20,6 +23,37 @@ describe('Locale and Formatting Utilities', () => {
       value: 'en-US',
       configurable: true,
     });
+    // Stub Intl.DateTimeFormat to return a neutral timezone so timezone-based
+    // detection doesn't interfere with navigator.language tests
+    originalIntl = global.Intl;
+    const MockIntl = {
+      ...Intl,
+      DateTimeFormat: Object.assign(
+        (locale?: string, options?: Intl.DateTimeFormatOptions) =>
+          new originalIntl.DateTimeFormat(locale, options),
+        {
+          ...Intl.DateTimeFormat,
+          prototype: Intl.DateTimeFormat.prototype,
+        }
+      ),
+    };
+    // Override resolvedOptions to return an unmapped timezone
+    MockIntl.DateTimeFormat = function(locale?: string, options?: Intl.DateTimeFormatOptions) {
+      const fmt = new originalIntl.DateTimeFormat(locale, options);
+      return {
+        ...fmt,
+        resolvedOptions: () => ({ ...fmt.resolvedOptions(), timeZone: 'UTC' }),
+        format: fmt.format.bind(fmt),
+        formatToParts: fmt.formatToParts.bind(fmt),
+        formatRange: fmt.formatRange?.bind(fmt),
+        formatRangeToParts: fmt.formatRangeToParts?.bind(fmt),
+      } as Intl.DateTimeFormat;
+    } as unknown as typeof Intl.DateTimeFormat;
+    global.Intl = MockIntl as typeof Intl;
+  });
+
+  afterEach(() => {
+    global.Intl = originalIntl;
   });
 
   describe('getUserLocale', () => {
@@ -28,7 +62,7 @@ describe('Locale and Formatting Utilities', () => {
       expect(getUserLocale()).toBe('en-IN');
     });
 
-    it('should return navigator.language when no stored preference', () => {
+    it('should return navigator.language directly for unambiguous locales (fr-FR)', () => {
       Object.defineProperty(navigator, 'language', {
         value: 'fr-FR',
         configurable: true,
@@ -37,13 +71,41 @@ describe('Locale and Formatting Utilities', () => {
       expect(getUserLocale()).toBe('fr-FR');
     });
 
-    it('should fallback to en-US when navigator.language unavailable', () => {
+    it('should return en-IN for unambiguous navigator.language en-IN', () => {
+      Object.defineProperty(navigator, 'language', {
+        value: 'en-IN',
+        configurable: true,
+      });
+
+      expect(getUserLocale()).toBe('en-IN');
+    });
+
+    it('should fallback to en-US when navigator.language unavailable and timezone unmapped', () => {
       Object.defineProperty(navigator, 'language', {
         value: undefined,
         configurable: true,
       });
 
+      // UTC is not in TIMEZONE_LOCALE_MAP → falls through to en-US
       expect(getUserLocale()).toBe('en-US');
+    });
+
+    it('should use timezone locale when navigator.language is generic (en-GB) and timezone maps to en-IN', () => {
+      Object.defineProperty(navigator, 'language', {
+        value: 'en-GB',
+        configurable: true,
+      });
+      // Override timezone to Asia/Kolkata
+      global.Intl = {
+        ...originalIntl,
+        DateTimeFormat: function() {
+          return {
+            resolvedOptions: () => ({ timeZone: 'Asia/Kolkata', locale: 'en-IN' }),
+          } as unknown as Intl.DateTimeFormat;
+        } as unknown as typeof Intl.DateTimeFormat,
+      } as typeof Intl;
+
+      expect(getUserLocale()).toBe('en-IN');
     });
 
     it('should prioritize stored preference over navigator.language', () => {
@@ -258,6 +320,59 @@ describe('Locale and Formatting Utilities', () => {
       const codes = AVAILABLE_LOCALES.map((l) => l.code);
       const uniqueCodes = new Set(codes);
       expect(codes.length).toBe(uniqueCodes.size);
+    });
+  });
+
+  describe('formatCompactCurrency', () => {
+    afterEach(() => {
+      clearUserLocale();
+    });
+
+    it('should format crore for INR locale', () => {
+      setUserLocale('en-IN');
+      expect(formatCompactCurrency(10_000_000)).toBe('₹1.0Cr');
+      expect(formatCompactCurrency(15_500_000)).toBe('₹1.6Cr');
+    });
+
+    it('should format lakh for INR locale', () => {
+      setUserLocale('en-IN');
+      expect(formatCompactCurrency(100_000)).toBe('₹1.0L');
+      expect(formatCompactCurrency(350_000)).toBe('₹3.5L');
+    });
+
+    it('should fall back to formatCurrency for INR below lakh threshold', () => {
+      setUserLocale('en-IN');
+      const result = formatCompactCurrency(50_000);
+      expect(result).toMatch(/₹|INR/);
+    });
+
+    it('should format millions for USD locale', () => {
+      setUserLocale('en-US');
+      expect(formatCompactCurrency(10_000_000)).toBe('$10.0M');
+      expect(formatCompactCurrency(1_500_000)).toBe('$1.5M');
+    });
+
+    it('should format thousands for USD locale', () => {
+      setUserLocale('en-US');
+      expect(formatCompactCurrency(5_000)).toBe('$5.0K');
+    });
+
+    it('should fall back to formatCurrency for USD below thousand threshold', () => {
+      setUserLocale('en-US');
+      const result = formatCompactCurrency(500);
+      expect(result).toMatch(/\$|USD/);
+    });
+
+    it('should use EUR symbol for de-DE locale', () => {
+      setUserLocale('de-DE');
+      const result = formatCompactCurrency(2_000_000);
+      expect(result).toMatch(/€.*M|M.*€/);
+    });
+
+    it('should fall back to USD for unknown locale', () => {
+      setUserLocale('en-US');
+      const result = formatCompactCurrency(1_000);
+      expect(result).toMatch(/\$|USD/);
     });
   });
 

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -7,11 +7,39 @@ import { useTheme } from '@mui/material/styles';
 const LOCALE_STORAGE_KEY = 'preferred_locale';
 
 /**
+ * Maps IANA timezone identifiers to locale strings for currency detection.
+ * Used as a secondary signal when navigator.language is ambiguous (e.g. en-GB
+ * on a device physically located in India).
+ */
+const TIMEZONE_LOCALE_MAP: Record<string, string> = {
+  'Asia/Kolkata': 'en-IN',
+  'Asia/Calcutta': 'en-IN',
+  'Asia/Tokyo': 'ja-JP',
+  'America/New_York': 'en-US',
+  'America/Chicago': 'en-US',
+  'America/Los_Angeles': 'en-US',
+  'Europe/London': 'en-GB',
+  'Europe/Berlin': 'de-DE',
+  'Europe/Paris': 'fr-FR',
+};
+
+/**
+ * Locales whose navigator.language value already carries an unambiguous
+ * currency region (e.g. 'en-IN' → INR, 'hi-IN' → INR). For these we trust
+ * navigator.language directly. For generic locales like 'en-GB' or 'en-US'
+ * we cross-check with the system timezone before committing.
+ */
+const UNAMBIGUOUS_LOCALES = new Set(['en-IN', 'hi-IN', 'ja-JP', 'de-DE', 'fr-FR']);
+
+/**
  * Gets the user's preferred locale.
  * Priority:
  * 1. Stored preference in localStorage
- * 2. Browser's navigator.language
- * 3. Fallback to 'en-US'
+ * 2. navigator.language — if it carries an unambiguous currency region, use it
+ * 3. System timezone (Intl.DateTimeFormat) — more reliable than browser language
+ *    for determining currency when the browser is set to a generic English locale
+ * 4. navigator.language as-is
+ * 5. Fallback to 'en-US'
  */
 export const getUserLocale = (): string => {
   // Check for stored preference first
@@ -20,12 +48,31 @@ export const getUserLocale = (): string => {
     return storedLocale;
   }
 
-  // Use browser's language setting
-  if (typeof navigator !== 'undefined' && navigator.language) {
-    return navigator.language;
+  const browserLocale =
+    typeof navigator !== 'undefined' ? navigator.language : undefined;
+
+  // If the browser reports an unambiguous locale (e.g. en-IN), trust it directly
+  if (browserLocale && UNAMBIGUOUS_LOCALES.has(browserLocale)) {
+    return browserLocale;
   }
 
-  // Fallback
+  // For generic locales (en-GB, en-US, en, …) use the system timezone as a
+  // stronger signal for the user's actual currency region
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const tzLocale = TIMEZONE_LOCALE_MAP[tz];
+    if (tzLocale) {
+      return tzLocale;
+    }
+  } catch {
+    // Intl not available — fall through
+  }
+
+  // Fall back to whatever navigator.language reported
+  if (browserLocale) {
+    return browserLocale;
+  }
+
   return 'en-US';
 };
 
@@ -112,6 +159,57 @@ export const formatIndianNumber = (
  */
 export const formatIndianCurrency = (num: number): string => {
   return formatCurrency(num, 'INR');
+};
+
+/**
+ * Formats a number as a compact currency string suitable for chart axis labels.
+ * Uses locale-appropriate magnitude suffixes:
+ * - INR: ₹10.5Cr (crore = 10M), ₹3.5L (lakh = 100K)
+ * - Others (USD, EUR, GBP, JPY, ...): $10.5M, $3.5K
+ * Falls back to formatCurrency for values below the compact threshold.
+ *
+ * @param num - The number to format
+ */
+export const formatCompactCurrency = (num: number): string => {
+  const locale = getUserLocale();
+  const localeCurrencyMap: { [key: string]: string } = {
+    'en-IN': 'INR',
+    'hi-IN': 'INR',
+    'en-US': 'USD',
+    'en-GB': 'GBP',
+    'de-DE': 'EUR',
+    'fr-FR': 'EUR',
+    'ja-JP': 'JPY',
+  };
+  const currency = localeCurrencyMap[locale] || 'USD';
+
+  if (currency === 'INR') {
+    if (num >= 10_000_000) {
+      return `₹${(num / 10_000_000).toFixed(1)}Cr`;
+    }
+    if (num >= 100_000) {
+      return `₹${(num / 100_000).toFixed(1)}L`;
+    }
+    return formatCurrency(num, 'INR');
+  }
+
+  // For all other currencies: extract the symbol from a zero-amount format
+  const symbol = (0)
+    .toLocaleString(locale, {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0,
+    })
+    .replace(/[\d,.\s]/g, '')
+    .trim();
+
+  if (num >= 1_000_000) {
+    return `${symbol}${(num / 1_000_000).toFixed(1)}M`;
+  }
+  if (num >= 1_000) {
+    return `${symbol}${(num / 1_000).toFixed(1)}K`;
+  }
+  return formatCurrency(num, currency);
 };
 
 export const useNumberFormatter = (num: number) => {

--- a/src/util/storage/googleDriveProvider.ts
+++ b/src/util/storage/googleDriveProvider.ts
@@ -295,6 +295,7 @@ export class GoogleDriveProvider implements StorageProvider {
           g.startDate,
           g.targetDate,
           g.targetAmount,
+          g.recurringDurationYears,
         );
       });
       const investmentLogs = Array.isArray(parsed.investmentLogs)

--- a/src/util/storage/localFileProvider.ts
+++ b/src/util/storage/localFileProvider.ts
@@ -218,6 +218,7 @@ export class LocalFileProvider implements StorageProvider {
           g.startDate,
           g.targetDate,
           g.targetAmount,
+          g.recurringDurationYears,
         );
       });
       const investmentLogs = Array.isArray(parsed.investmentLogs)


### PR DESCRIPTION
- Replace all hardcoded ₹ symbols with formatCurrency() so amounts render with the correct symbol and number grouping for each locale
- Add formatCompactCurrency() for chart Y-axis labels (Cr/L for INR, M/K for others)
- Fix timezone-based locale detection so Arc/en-GB users in India see ₹ instead of £ (uses Intl.DateTimeFormat timezone as secondary signal)
- Add recurringDurationYears field to FinancialGoal; SIP calculation uses target ÷ (duration × 12); duration shown as radio buttons (1 / 2 / 3 years) in the goal form and as a column in the table