### PR TITLE
feature: layout redesign — stat strip, goal chips, compact allocation…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # goal-based-financial-planner Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-06-07
+Auto-generated from all feature plans. Last updated: 2026-07-11
 
 ## Active Technologies
 - TypeScript (React 18, CRA / react-scripts 5) + MUI v6 (`@mui/material` — Tabs, Tab already available), React 18 hooks (004-goals-tabbed-view)
@@ -23,6 +23,8 @@ Auto-generated from all feature plans. Last updated: 2026-06-07
 - Browser `localStorage` (local) + Google Drive REST API (cloud) — via `src/util/storage/storageProvider.ts` (013-configurable-inflation-rate)
 - TypeScript 4.x + React 19.2.4 + `@mui/material` v6, `@mui/x-charts` ^7.23.6 (already installed), `dayjs` ^1.11.13 (014-portfolio-growth-chart)
 - None — all projection data is derived at render time from existing `localStorage` / Google Drive data (014-portfolio-growth-chart)
+- TypeScript 4.x + React 19.2.4 + MUI v6 (`@mui/material`, `@mui/x-charts`), `dayjs`, Vite 8.0.0 (016-layout-redesign)
+- Browser `localStorage` / Google Drive — no changes (016-layout-redesign)
 
 - Markdown / N/A (documentation only) + N/A (static documentation files) (003-oss-documentation)
 
@@ -43,9 +45,9 @@ tests/
 Markdown / N/A (documentation only): Follow standard conventions
 
 ## Recent Changes
+- 016-layout-redesign: Added TypeScript 4.x + React 19.2.4 + MUI v6 (`@mui/material`, `@mui/x-charts`), `dayjs`, Vite 8.0.0
 - 014-portfolio-growth-chart: Added TypeScript 4.x + React 19.2.4 + `@mui/material` v6, `@mui/x-charts` ^7.23.6 (already installed), `dayjs` ^1.11.13
 - 013-configurable-inflation-rate: Added TypeScript 4.x + React 19.2.4, MUI v6 (`@mui/material`), react-hook-form (existing), Vite 8.0.0, Vites
-- 012-onboarding-wizard: Added TypeScript 4.x + React 19.2.4 + MUI v6 (`@mui/material` — Dialog, Stepper/MobileStepper, Button, Typography), react-hook-form (existing), Vite 8.0.0, Vites
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/src/pages/LandingPage/components/OnboardingWizard/index.test.tsx
+++ b/src/pages/LandingPage/components/OnboardingWizard/index.test.tsx
@@ -54,9 +54,9 @@ describe('OnboardingWizard shell', () => {
     expect(screen.getByText('Step 1 of 4')).toBeInTheDocument();
   });
 
-  it('Skip button is visible on step 1', () => {
+  it('Skip button is not rendered', () => {
     render(<OnboardingWizard {...defaultProps} />, { wrapper });
-    expect(screen.getByRole('button', { name: /skip/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /skip/i })).not.toBeInTheDocument();
   });
 
   it('Back button is not accessible on step 1', () => {
@@ -104,13 +104,6 @@ describe('OnboardingWizard shell', () => {
     fireEvent.click(screen.getByText('goal-done'));
     expect(defaultProps.onNewPlanCreated).toHaveBeenCalledTimes(1);
     expect(defaultProps.onComplete).not.toHaveBeenCalled();
-  });
-
-  it('Skip button calls onComplete (not onNewPlanCreated)', () => {
-    render(<OnboardingWizard {...defaultProps} />, { wrapper });
-    fireEvent.click(screen.getByRole('button', { name: /skip/i }));
-    expect(defaultProps.onComplete).toHaveBeenCalledTimes(1);
-    expect(defaultProps.onNewPlanCreated).not.toHaveBeenCalled();
   });
 
   it('progress bar reflects current step', () => {

--- a/src/pages/LandingPage/components/OnboardingWizard/index.tsx
+++ b/src/pages/LandingPage/components/OnboardingWizard/index.tsx
@@ -46,12 +46,9 @@ const OnboardingWizard: React.FC<OnboardingWizardProps> = ({
     isLastStep,
     goNext,
     goBack,
-    skip,
     handleStorageSelected,
     handleGoalCreated,
   } = useOnboardingWizard();
-
-  const handleSkip = () => skip(onComplete);
 
   const progress = ((currentStep - 1) / (totalSteps - 1)) * 100;
 
@@ -93,7 +90,7 @@ const OnboardingWizard: React.FC<OnboardingWizardProps> = ({
       fullScreen={fullScreen}
       fullWidth
       maxWidth="sm"
-      onClose={handleSkip}
+      onClose={onComplete}
       aria-label="Onboarding wizard"
       disableEscapeKeyDown={false}
     >
@@ -111,9 +108,6 @@ const OnboardingWizard: React.FC<OnboardingWizardProps> = ({
         <Typography variant="body2" color="text.secondary">
           Step {currentStep} of {totalSteps}
         </Typography>
-        <Button size="small" color="inherit" onClick={handleSkip} sx={{ color: 'text.secondary' }}>
-          Skip
-        </Button>
       </Box>
 
       {/* Progress bar */}

--- a/src/pages/LandingPage/components/OnboardingWizard/useOnboardingWizard.test.ts
+++ b/src/pages/LandingPage/components/OnboardingWizard/useOnboardingWizard.test.ts
@@ -70,24 +70,6 @@ describe('useOnboardingWizard', () => {
     });
   });
 
-  describe('skip', () => {
-    it('calls onComplete', () => {
-      const { result } = renderHook(() => useOnboardingWizard());
-      const onComplete = vi.fn();
-      act(() => result.current.skip(onComplete));
-      expect(onComplete).toHaveBeenCalledTimes(1);
-    });
-
-    it('skip works from any step', () => {
-      const { result } = renderHook(() => useOnboardingWizard());
-      act(() => result.current.goNext());
-      act(() => result.current.goNext());
-      const onComplete = vi.fn();
-      act(() => result.current.skip(onComplete));
-      expect(onComplete).toHaveBeenCalledTimes(1);
-    });
-  });
-
   describe('handleGoalCreated', () => {
     it('calls onComplete', () => {
       const { result } = renderHook(() => useOnboardingWizard());

--- a/src/pages/LandingPage/components/OnboardingWizard/useOnboardingWizard.ts
+++ b/src/pages/LandingPage/components/OnboardingWizard/useOnboardingWizard.ts
@@ -9,7 +9,6 @@ export type UseOnboardingWizardReturn = {
   isLastStep: boolean;
   goNext: () => void;
   goBack: () => void;
-  skip: (onComplete: () => void) => void;
   handleStorageSelected: () => void;
   handleGoalCreated: (onComplete: () => void) => void;
 };
@@ -28,10 +27,6 @@ export function useOnboardingWizard(): UseOnboardingWizardReturn {
     setCurrentStep((s) => Math.max(s - 1, 1));
   }, []);
 
-  const skip = useCallback((onComplete: () => void) => {
-    onComplete();
-  }, []);
-
   const handleStorageSelected = useCallback(() => {
     setCurrentStep(4);
   }, []);
@@ -47,7 +42,6 @@ export function useOnboardingWizard(): UseOnboardingWizardReturn {
     isLastStep: currentStep === TOTAL_STEPS,
     goNext,
     goBack,
-    skip,
     handleStorageSelected,
     handleGoalCreated,
   };

--- a/src/pages/Planner/components/CustomLegend/__snapshots__/index.test.tsx.snap
+++ b/src/pages/Planner/components/CustomLegend/__snapshots__/index.test.tsx.snap
@@ -3,79 +3,158 @@
 exports[`CustomLegend > should match snapshot 1`] = `
 <div>
   <div
-    class="MuiTableContainer-root MuiBox-root css-jd4hnh-MuiTableContainer-root"
+    class="MuiBox-root css-k5rr6j"
   >
-    <table
-      class="MuiTable-root css-1xwxv7r-MuiTable-root"
+    <div
+      class="MuiBox-root css-okmndc"
     >
-      <tbody
-        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+      <div
+        class="css-5h5k6k-MuiResponsiveChart-container"
       >
-        <tr
-          class="MuiTableRow-root css-6phqnb-MuiTableRow-root"
+        <svg
+          class="css-1evyvmv-MuiChartsSurface-root"
+          height="110"
+          viewBox="0 0 110 110"
+          width="110"
         >
-          <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1lb47ru-MuiTableCell-root"
-          >
-            <div
-              class="MuiBox-root css-ya7p3"
-            />
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1lb47ru-MuiTableCell-root"
-          >
-            Large Cap Equity
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jlqdff-MuiTableCell-root"
-          >
-            $4,000,000
-          </td>
-        </tr>
-        <tr
-          class="MuiTableRow-root css-6phqnb-MuiTableRow-root"
+          <title />
+          <desc />
+          <defs />
+          <g>
+            <g
+              transform="translate(55, 55)"
+            >
+              <g>
+                <path
+                  class="MuiPieArc-root MuiPieArc-series-auto-generated-id-0 MuiPieArc-data-index-0 css-1mzvvpl-MuiPieArc-root"
+                  cursor="unset"
+                  d="M34.11,18.908L24.489,13.575Z"
+                  fill="rgba(255, 165, 0, 0.8)"
+                  filter="none"
+                  opacity="1"
+                  stroke-linejoin="round"
+                  stroke-width="1"
+                  visibility="hidden"
+                />
+                <path
+                  class="MuiPieArc-root MuiPieArc-series-auto-generated-id-0 MuiPieArc-data-index-1 css-1mzvvpl-MuiPieArc-root"
+                  cursor="unset"
+                  d="M-38.987,1.021L-27.99,0.733Z"
+                  fill="rgba(54, 162, 235, 0.8)"
+                  filter="none"
+                  opacity="1"
+                  stroke-linejoin="round"
+                  stroke-width="1"
+                  visibility="hidden"
+                />
+                <path
+                  class="MuiPieArc-root MuiPieArc-series-auto-generated-id-0 MuiPieArc-data-index-2 css-1mzvvpl-MuiPieArc-root"
+                  cursor="unset"
+                  d="M-19.794,-33.604L-14.211,-24.126Z"
+                  fill="rgba(75, 192, 192, 0.8)"
+                  filter="none"
+                  opacity="1"
+                  stroke-linejoin="round"
+                  stroke-width="1"
+                  visibility="hidden"
+                />
+              </g>
+            </g>
+            <g
+              transform="translate(55, 55)"
+            >
+              <g>
+                <text
+                  class="MuiPieArcLabel-root MuiPieArcLabel-series-auto-generated-id-0 css-ixpz1i-MuiPieArcLabel-root"
+                  style="opacity: 0; transform: none;"
+                />
+                <text
+                  class="MuiPieArcLabel-root MuiPieArcLabel-series-auto-generated-id-0 css-ixpz1i-MuiPieArcLabel-root"
+                  style="opacity: 0; transform: none;"
+                />
+                <text
+                  class="MuiPieArcLabel-root MuiPieArcLabel-series-auto-generated-id-0 css-ixpz1i-MuiPieArcLabel-root"
+                  style="opacity: 0; transform: none;"
+                />
+              </g>
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-6c794j"
+    >
+      <div
+        class="MuiBox-root css-172hjuw"
+      >
+        <div
+          class="MuiBox-root css-um6r64"
+        />
+        <span
+          class="MuiBox-root css-gorx6i"
         >
-          <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1lb47ru-MuiTableCell-root"
-          >
-            <div
-              class="MuiBox-root css-ck996r"
-            />
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1lb47ru-MuiTableCell-root"
-          >
-            Gold
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jlqdff-MuiTableCell-root"
-          >
-            $1,000,000
-          </td>
-        </tr>
-        <tr
-          class="MuiTableRow-root css-6phqnb-MuiTableRow-root"
+          Large Cap Equity
+        </span>
+        <span
+          class="MuiBox-root css-gof1rv"
         >
-          <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1lb47ru-MuiTableCell-root"
-          >
-            <div
-              class="MuiBox-root css-d6x00p"
-            />
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1lb47ru-MuiTableCell-root"
-          >
-            PPF
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jlqdff-MuiTableCell-root"
-          >
-            $1,000,000
-          </td>
-        </tr>
-      </tbody>
-    </table>
+          67
+          %
+        </span>
+        <span
+          class="MuiBox-root css-bh4ibf"
+        >
+          $4,000,000
+        </span>
+      </div>
+      <div
+        class="MuiBox-root css-172hjuw"
+      >
+        <div
+          class="MuiBox-root css-dqa00k"
+        />
+        <span
+          class="MuiBox-root css-gorx6i"
+        >
+          Gold
+        </span>
+        <span
+          class="MuiBox-root css-gof1rv"
+        >
+          17
+          %
+        </span>
+        <span
+          class="MuiBox-root css-bh4ibf"
+        >
+          $1,000,000
+        </span>
+      </div>
+      <div
+        class="MuiBox-root css-172hjuw"
+      >
+        <div
+          class="MuiBox-root css-171r4kw"
+        />
+        <span
+          class="MuiBox-root css-gorx6i"
+        >
+          PPF
+        </span>
+        <span
+          class="MuiBox-root css-gof1rv"
+        >
+          17
+          %
+        </span>
+        <span
+          class="MuiBox-root css-bh4ibf"
+        >
+          $1,000,000
+        </span>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/src/pages/Planner/components/CustomLegend/index.test.tsx
+++ b/src/pages/Planner/components/CustomLegend/index.test.tsx
@@ -60,10 +60,9 @@ describe('CustomLegend', () => {
     expect(screen.getByText('$4,000,000')).toBeInTheDocument();
   });
 
-  it('should handle empty suggestions', () => {
-    render(<CustomLegend suggestions={[]} />);
-    const tbody = screen.queryByRole('rowgroup');
-    expect(tbody).toBeInTheDocument();
+  it('should handle empty suggestions without crashing', () => {
+    const { container } = render(<CustomLegend suggestions={[]} />);
+    expect(container.firstChild).toBeInTheDocument();
   });
 
   it('should match snapshot', () => {

--- a/src/pages/Planner/components/CustomLegend/index.tsx
+++ b/src/pages/Planner/components/CustomLegend/index.tsx
@@ -1,21 +1,29 @@
-import {
-  Box,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableRow,
-  useMediaQuery,
-  useTheme,
-} from '@mui/material';
+import { Box, IconButton, Tooltip } from '@mui/material';
+import { PieChart } from '@mui/x-charts';
 
 import { GoalWiseInvestmentSuggestions } from '../../hooks/useInvestmentCalculator';
 import { formatCurrency } from '../../../../types/util';
 import { InvestmentAmountMap } from '../../../../types/charts';
 import { memo, useMemo } from 'react';
 
+const PALETTE = [
+  'rgba(255, 165, 0, 0.8)',
+  'rgba(54, 162, 235, 0.8)',
+  'rgba(75, 192, 192, 0.8)',
+  'rgba(50, 205, 50, 0.8)',
+  'rgba(255, 99, 132, 0.8)',
+];
+
 const CustomLegend = memo(
-  ({ suggestions }: { suggestions: GoalWiseInvestmentSuggestions[] }) => {
+  ({
+    suggestions,
+    label,
+    onCustomize,
+  }: {
+    suggestions: GoalWiseInvestmentSuggestions[];
+    label?: string;
+    onCustomize?: () => void;
+  }) => {
     const investmentOptionWiseSum = useMemo(
       () =>
         suggestions.reduce(
@@ -23,7 +31,6 @@ const CustomLegend = memo(
             goal.investmentSuggestions.forEach(({ investmentName, amount }) => {
               acc[investmentName] = (acc[investmentName] || 0) + amount;
             });
-
             return acc;
           },
           {} as InvestmentAmountMap,
@@ -31,51 +38,90 @@ const CustomLegend = memo(
       [suggestions],
     );
 
-  const palette = [
-    'rgba(255, 165, 0, 0.8)',
-    'rgba(54, 162, 235, 0.8)',
-    'rgba(75, 192, 192, 0.8)',
-    'rgba(50, 205, 50, 0.8)',
-    'rgba(255, 99, 132, 0.8)',
-  ];
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-  return (
-    <TableContainer component={Box}>
-      <Table size="small">
-        <TableBody>
-          {Object.entries(investmentOptionWiseSum).map(
-            ([key, value], index) => {
-              const color = palette[index % palette.length];
-              return (
-                <TableRow
-                  key={key}
-                  sx={{
-                    '&:last-child td, &:last-child th': { border: 0 },
-                  }}
-                >
-                  <TableCell sx={{ padding: '4px 8px' }}>
-                    <Box
-                      sx={{
-                        width: isMobile ? 6 : 10,
-                        height: isMobile ? 6 : 10,
-                        backgroundColor: color,
-                      }}
-                    />
-                  </TableCell>
-                  <TableCell sx={{ padding: '4px 8px' }}>{key}</TableCell>
-                  <TableCell sx={{ padding: '4px 8px', textAlign: 'right' }}>
-                    {formatCurrency(Math.round(value))}
-                  </TableCell>
-                </TableRow>
-              );
-            },
-          )}
-        </TableBody>
-      </Table>
-    </TableContainer>
-  );
-});
+    const entries = useMemo(() => Object.entries(investmentOptionWiseSum), [investmentOptionWiseSum]);
+    const total = useMemo(() => entries.reduce((sum, [, v]) => sum + v, 0), [entries]);
+
+    const pieData = useMemo(
+      () =>
+        entries.map(([name, value], i) => ({
+          id: i,
+          value,
+          label: name,
+          color: PALETTE[i % PALETTE.length],
+        })),
+      [entries],
+    );
+
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+        {/* Left: pie + term label + customize button */}
+        {pieData.length > 0 && (
+          <Box sx={{ flexShrink: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
+            <PieChart
+              series={[{
+                data: pieData,
+                innerRadius: 28,
+                outerRadius: 50,
+                paddingAngle: 2,
+                cornerRadius: 3,
+                highlightScope: { faded: 'global', highlighted: 'item' },
+                valueFormatter: (item) => {
+                  const pct = total > 0 ? ((item.value / total) * 100).toFixed(1) : '0';
+                  return `${pct}% (${formatCurrency(Math.round(item.value))})`;
+                },
+              }]}
+              width={110}
+              height={110}
+              margin={{ top: 2, bottom: 2, left: 2, right: 2 }}
+              slotProps={{ legend: { hidden: true } }}
+            />
+            {label && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+                <Box component="span" sx={{ fontSize: '0.65rem', color: 'text.secondary', fontWeight: 500, letterSpacing: 0.3 }}>
+                  {label}
+                </Box>
+                {onCustomize && (
+                  <Tooltip title="Customize allocation" arrow>
+                    <IconButton
+                      size="small"
+                      onClick={onCustomize}
+                      className="customize-button"
+                      sx={{ color: 'success.main', p: 0.25 }}
+                    >
+                      <span className="material-symbols-rounded" style={{ fontSize: '14px' }}>tune</span>
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </Box>
+            )}
+          </Box>
+        )}
+
+        {/* Right: horizontal legend rows */}
+        <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+          {entries.map(([key, value], index) => {
+            const color = PALETTE[index % PALETTE.length];
+            const pct = total > 0 ? Math.round((value / total) * 100) : 0;
+            return (
+              <Box key={key} sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                <Box sx={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: color, flexShrink: 0 }} />
+                <Box component="span" sx={{ flex: 1, fontSize: '0.82rem', color: 'text.secondary', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {key}
+                </Box>
+                <Box component="span" sx={{ fontSize: '0.75rem', color: 'text.disabled', flexShrink: 0 }}>
+                  {pct}%
+                </Box>
+                <Box component="span" sx={{ fontSize: '0.92rem', fontWeight: 600, color: 'text.primary', whiteSpace: 'nowrap', flexShrink: 0 }}>
+                  {formatCurrency(Math.round(value))}
+                </Box>
+              </Box>
+            );
+          })}
+        </Box>
+      </Box>
+    );
+  },
+);
 
 CustomLegend.displayName = 'CustomLegend';
 

--- a/src/pages/Planner/components/GoalBox/goalList.tsx
+++ b/src/pages/Planner/components/GoalBox/goalList.tsx
@@ -1,5 +1,5 @@
 import GoalCard from '../GoalCard';
-import { Box, Divider } from '@mui/material';
+import { Grid2 as Grid } from '@mui/material';
 import { GoalWiseInvestmentSuggestions } from '../../hooks/useInvestmentCalculator';
 import { FinancialGoal } from '../../../../domain/FinancialGoals';
 import { PlannerDataAction } from '../../../../store/plannerDataReducer';
@@ -17,37 +17,24 @@ const GoalList = ({
   dispatch,
 }: GoalListProps) => {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 2,
-        '& .divider': {
-          display: 'block',
-        },
-        '& .divider:last-child': {
-          display: 'none',
-        },
-      }}
-    >
+    <Grid container spacing={2}>
       {goals.map((goal: FinancialGoal) => {
         const investmentBreakdown = investmentBreakdownForAllGoals.find(
           (ib) => ib.goalName === goal.getGoalName(),
         );
 
         return (
-          <div key={goal.id}>
+          <Grid key={goal.id} size={{ xs: 12, sm: 6 }}>
             <GoalCard
               goal={goal}
               dispatch={dispatch}
               currentValue={investmentBreakdown?.currentValue ?? 0}
               investmentSuggestions={investmentBreakdown?.investmentSuggestions}
             />
-            <Divider className="divider" />
-          </div>
+          </Grid>
         );
       })}
-    </Box>
+    </Grid>
   );
 };
 

--- a/src/pages/Planner/components/GoalBox/index.test.tsx
+++ b/src/pages/Planner/components/GoalBox/index.test.tsx
@@ -100,7 +100,7 @@ describe('GoalBox', () => {
   });
 
   describe('One Time tab content', () => {
-    it('should show pending goals under "Financial Goals" heading', () => {
+    it('should show pending goals', () => {
       render(
         <GoalBox
           {...defaultProps}
@@ -108,7 +108,6 @@ describe('GoalBox', () => {
         />,
       );
 
-      expect(screen.getByText('Financial Goals')).toBeInTheDocument();
       expect(screen.getByTestId('goal-House Fund')).toBeInTheDocument();
     });
 
@@ -160,7 +159,7 @@ describe('GoalBox', () => {
 
       fireEvent.click(screen.getByRole('tab', { name: /Recurring/i }));
 
-      expect(screen.queryByText('Financial Goals')).not.toBeVisible();
+      expect(screen.queryByTestId('goal-House Fund')).not.toBeVisible();
     });
 
     it('should show empty state when no recurring goals exist', () => {

--- a/src/pages/Planner/components/GoalBox/index.tsx
+++ b/src/pages/Planner/components/GoalBox/index.tsx
@@ -87,16 +87,11 @@ const GoalBox = ({
         ) : (
           <>
             {pendingGoals.length > 0 && (
-              <>
-                <Typography variant="h6" fontWeight="bold">
-                  Financial Goals
-                </Typography>
-                <GoalList
-                  investmentBreakdownForAllGoals={investmentBreakdownForAllGoals}
-                  goals={pendingGoals}
-                  dispatch={dispatch}
-                />
-              </>
+              <GoalList
+                investmentBreakdownForAllGoals={investmentBreakdownForAllGoals}
+                goals={pendingGoals}
+                dispatch={dispatch}
+              />
             )}
             {completedGoals.length > 0 && (
               <>

--- a/src/pages/Planner/components/GoalCard/components/InvestmentTracker/index.test.tsx
+++ b/src/pages/Planner/components/GoalCard/components/InvestmentTracker/index.test.tsx
@@ -4,10 +4,6 @@ import InvestmentTracker from './index';
 import { SIPEntry } from '../../../../../../types/investmentLog';
 import { InvestmentSuggestion } from '../../../../../../types/planner';
 
-vi.mock('../../../GoalGrowthChart', () => ({
-  default: () => <div data-testid="goal-growth-chart">Growth Chart</div>,
-}));
-
 const mockDispatch = jest.fn();
 
 const suggestions: InvestmentSuggestion[] = [
@@ -25,23 +21,16 @@ const sip: SIPEntry = {
 describe('InvestmentTracker', () => {
   afterEach(() => jest.clearAllMocks());
 
-  it('renders the growth chart', () => {
-    render(
-      <InvestmentTracker investmentSuggestions={suggestions} sips={[]} goals={[]} dispatch={mockDispatch} />,
-    );
-    expect(screen.getByTestId('goal-growth-chart')).toBeInTheDocument();
-  });
-
   it('renders the Add SIP button', () => {
     render(
-      <InvestmentTracker investmentSuggestions={suggestions} sips={[]} goals={[]} dispatch={mockDispatch} />,
+      <InvestmentTracker investmentSuggestions={suggestions} sips={[]} dispatch={mockDispatch} />,
     );
     expect(screen.getByRole('button', { name: /add sip/i })).toBeInTheDocument();
   });
 
   it('renders comparison cards for each suggestion type', () => {
     render(
-      <InvestmentTracker investmentSuggestions={suggestions} sips={[sip]} goals={[]} dispatch={mockDispatch} />,
+      <InvestmentTracker investmentSuggestions={suggestions} sips={[sip]} dispatch={mockDispatch} />,
     );
     expect(screen.getAllByText('Liquid Funds').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('Index Funds').length).toBeGreaterThanOrEqual(1);
@@ -49,7 +38,7 @@ describe('InvestmentTracker', () => {
 
   it('renders SIP list section when SIPs exist', () => {
     render(
-      <InvestmentTracker investmentSuggestions={suggestions} sips={[sip]} goals={[]} dispatch={mockDispatch} />,
+      <InvestmentTracker investmentSuggestions={suggestions} sips={[sip]} dispatch={mockDispatch} />,
     );
     expect(screen.getByText('Axis Bank Liquid Fund')).toBeInTheDocument();
   });
@@ -57,25 +46,17 @@ describe('InvestmentTracker', () => {
   it('shows "Not in plan" chip for custom SIP types', () => {
     const customSip: SIPEntry = { id: 'c1', name: 'PPF', type: 'PPF', monthlyAmount: 12500 };
     render(
-      <InvestmentTracker investmentSuggestions={suggestions} sips={[customSip]} goals={[]} dispatch={mockDispatch} />,
+      <InvestmentTracker investmentSuggestions={suggestions} sips={[customSip]} dispatch={mockDispatch} />,
     );
     expect(screen.getByText('Not in plan')).toBeInTheDocument();
   });
 
-  it('shows monthly required and "No SIPs logged yet" when no SIPs', () => {
+  it('shows "X% met" when investing less than required', () => {
     render(
-      <InvestmentTracker investmentSuggestions={suggestions} sips={[]} goals={[]} dispatch={mockDispatch} />,
+      <InvestmentTracker investmentSuggestions={suggestions} sips={[sip]} dispatch={mockDispatch} />,
     );
-    expect(screen.getByText('Monthly Required')).toBeInTheDocument();
-    expect(screen.getByText('Monthly Investing')).toBeInTheDocument();
-    expect(screen.getByText('No SIPs logged yet')).toBeInTheDocument();
-  });
-
-  it('shows "short" status when investing less than required', () => {
-    render(
-      <InvestmentTracker investmentSuggestions={suggestions} sips={[sip]} goals={[]} dispatch={mockDispatch} />,
-    );
-    expect(screen.getByText(/short/i)).toBeInTheDocument();
+    // sip covers 40000/25000 of Liquid Funds (exceeding) and 0/50000 of Index Funds (0% met)
+    expect(screen.getByText(/\d+% met/i)).toBeInTheDocument();
   });
 
   it('shows "On track" when investing at least as much as required', () => {
@@ -84,7 +65,7 @@ describe('InvestmentTracker', () => {
       { id: 's2', name: 'Index', type: 'Index Funds', monthlyAmount: 50000 },
     ];
     render(
-      <InvestmentTracker investmentSuggestions={suggestions} sips={fullSips} goals={[]} dispatch={mockDispatch} />,
+      <InvestmentTracker investmentSuggestions={suggestions} sips={fullSips} dispatch={mockDispatch} />,
     );
     expect(screen.getAllByText('On track').length).toBeGreaterThanOrEqual(1);
   });

--- a/src/pages/Planner/components/GoalCard/components/InvestmentTracker/index.tsx
+++ b/src/pages/Planner/components/GoalCard/components/InvestmentTracker/index.tsx
@@ -5,36 +5,27 @@ import { PlannerDataAction } from '../../../../../../store/plannerDataReducer';
 import { deleteInvestmentLogEntry } from '../../../../../../store/plannerDataActions';
 import { InvestmentSuggestion } from '../../../../../../types/planner';
 import { SIPEntry } from '../../../../../../types/investmentLog';
-import { FinancialGoal } from '../../../../../../domain/FinancialGoals';
-import { buildSIPComparison, GoalSuggestion } from '../../../../../../domain/investmentLog';
+import { buildSIPComparison } from '../../../../../../domain/investmentLog';
 import { formatCurrency } from '../../../../../../types/util';
 import SIPForm from '../LogEntryForm';
 import SIPList from '../InvestmentLogHistory';
-import GoalGrowthChart from '../../../GoalGrowthChart';
 
 type Props = {
   investmentSuggestions: InvestmentSuggestion[];
   sips: SIPEntry[];
-  goals: FinancialGoal[];
   dispatch: Dispatch<PlannerDataAction>;
-  goalWiseSuggestions?: GoalSuggestion[];
 };
 
 const InvestmentTracker = ({
   investmentSuggestions,
   sips = [],
-  goals = [],
   dispatch,
-  goalWiseSuggestions,
 }: Props) => {
   const [formOpen, setFormOpen] = useState(false);
   const [editingEntry, setEditingEntry] = useState<SIPEntry | undefined>(undefined);
 
   const investmentTypes = investmentSuggestions.map((s) => s.investmentName);
   const comparison = buildSIPComparison(sips, investmentSuggestions);
-
-  const totalRequired = Math.round(comparison.reduce((sum, r) => sum + r.suggestedAmount, 0));
-  const totalInvesting = Math.round(comparison.reduce((sum, r) => sum + r.actualAmount, 0));
 
   const handleEdit = (entry: SIPEntry) => {
     setEditingEntry(entry);
@@ -46,62 +37,9 @@ const InvestmentTracker = ({
   };
 
   return (
-    <Box sx={{ mt: 1 }}>
-      {/* Monthly summary */}
-      <Grid container spacing={2} sx={{ mb: 2 }}>
-        <Grid size={{ xs: 6 }}>
-          <Box
-            sx={{
-              p: 1.5,
-              borderRadius: 1.5,
-              border: '1px solid',
-              borderColor: 'divider',
-              backgroundColor: 'background.paper',
-            }}
-          >
-            <Typography variant="overline" color="text.secondary" sx={{ fontSize: '0.6rem', lineHeight: 1.4, display: 'block' }}>
-              Monthly Required
-            </Typography>
-            <Typography variant="subtitle1" fontWeight="bold" color="primary">
-              {formatCurrency(totalRequired)}
-            </Typography>
-            <Typography variant="caption" color="text.secondary">
-              /month across all goals
-            </Typography>
-          </Box>
-        </Grid>
-        <Grid size={{ xs: 6 }}>
-          <Box
-            sx={{
-              p: 1.5,
-              borderRadius: 1.5,
-              border: '1px solid',
-              borderColor: totalInvesting >= totalRequired ? 'success.main' : 'divider',
-              backgroundColor: 'background.paper',
-            }}
-          >
-            <Typography variant="overline" color="text.secondary" sx={{ fontSize: '0.6rem', lineHeight: 1.4, display: 'block' }}>
-              Monthly Investing
-            </Typography>
-            <Typography
-              variant="subtitle1"
-              fontWeight="bold"
-              color={totalInvesting >= totalRequired ? 'success.main' : totalInvesting > 0 ? 'warning.main' : 'text.secondary'}
-            >
-              {formatCurrency(totalInvesting)}
-            </Typography>
-            <Typography variant="caption" color="text.secondary">
-              {totalInvesting === 0 ? 'No SIPs logged yet' : totalInvesting >= totalRequired ? 'On track' : `${formatCurrency(totalRequired - totalInvesting)} short`}
-            </Typography>
-          </Box>
-        </Grid>
-      </Grid>
-
-      {/* Portfolio growth chart with withdrawal simulation */}
-      <GoalGrowthChart sips={sips} goals={goals} allSuggestions={investmentSuggestions} goalWiseSuggestions={goalWiseSuggestions} />
-
+    <Box>
       {/* Comparison + SIP list side by side */}
-      <Grid container spacing={2} sx={{ mt: 1 }}>
+      <Grid container spacing={2}>
         {/* Left: comparison cards */}
         <Grid size={{ xs: 12, md: 6 }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>

--- a/src/pages/Planner/components/GoalCard/index.test.tsx
+++ b/src/pages/Planner/components/GoalCard/index.test.tsx
@@ -5,12 +5,6 @@ import { FinancialGoal } from '../../../../domain/FinancialGoals';
 import { GoalType } from '../../../../types/enums';
 import * as plannerDataActions from '../../../../store/plannerDataActions';
 
-vi.mock('react-progressbar-semicircle', () => ({
-  default: ({ percentage }: { percentage: number }) => (
-    <div data-testid="progress-bar">{percentage}%</div>
-  ),
-}));
-
 vi.mock('../../../../store/plannerDataActions', () => ({
   deleteFinancialGoal: vi.fn(),
   updateGoalInflationRate: vi.fn(),
@@ -113,7 +107,7 @@ describe('GoalCard', () => {
     expect(screen.getByTestId('financial-goal-form')).toBeInTheDocument();
   });
 
-  it('for recurring goals: progress bar section is NOT shown', () => {
+  it('for recurring goals: date range is NOT shown', () => {
     const goal = new FinancialGoal(
       'Monthly Savings',
       GoalType.RECURRING,
@@ -125,14 +119,14 @@ describe('GoalCard', () => {
     render(
       <GoalCard goal={goal} dispatch={mockDispatch} currentValue={0} />,
     );
-    expect(screen.queryByTestId('progress-bar')).not.toBeInTheDocument();
+    expect(screen.queryByText(/\d{2}\/\d{4} - \d{2}\/\d{4}/)).not.toBeInTheDocument();
   });
 
-  it('for one-time goals: progress bar section IS shown', () => {
+  it('for one-time goals: date range IS shown', () => {
     const goal = makeOneTimeGoal();
     render(
       <GoalCard goal={goal} dispatch={mockDispatch} currentValue={50000} />,
     );
-    expect(screen.getByTestId('progress-bar')).toBeInTheDocument();
+    expect(screen.getByText(/01\/2024 - 01\/2030/)).toBeInTheDocument();
   });
 });

--- a/src/pages/Planner/components/GoalCard/index.tsx
+++ b/src/pages/Planner/components/GoalCard/index.tsx
@@ -6,7 +6,6 @@ import {
   IconButton,
   Dialog,
 } from '@mui/material';
-import SemiCircleProgressBar from 'react-progressbar-semicircle';
 import { deleteFinancialGoal } from '../../../../store/plannerDataActions';
 import { FinancialGoal } from '../../../../domain/FinancialGoals';
 import dayjs from 'dayjs';
@@ -58,10 +57,6 @@ const GoalCard = memo(
     const formattedTargetAmount = formatCurrency(goal.getInflationAdjustedTargetAmount());
     const formattedNominalAmount = formatCurrency(goal.getTargetAmount());
 
-    const progressPercentage = Math.round(
-      (currentValue / goal.getInflationAdjustedTargetAmount()) * 100,
-    );
-
     const goalDuration = `${dayjs(goal.startDate).format('MM/YYYY')} - ${dayjs(
       goal.targetDate,
     ).format('MM/YYYY')}`;
@@ -79,9 +74,15 @@ const GoalCard = memo(
       <Box
         sx={{
           position: 'relative',
-          px: 1,
-          py: 1,
+          px: 2,
+          py: 1.5,
           borderRadius: 2,
+          border: '1px solid',
+          borderColor: 'divider',
+          backgroundColor: 'background.paper',
+          boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+          transition: 'box-shadow 0.15s ease',
+          '&:hover': { boxShadow: '0 3px 8px rgba(0,0,0,0.1)' },
         }}
       >
         {/* Main card row */}
@@ -90,7 +91,7 @@ const GoalCard = memo(
             display: 'flex',
             justifyContent: 'space-between',
             flexDirection: 'row',
-            pr: 4, // Space for the button column
+            pr: 4,
           }}
         >
           {/* Left section */}
@@ -108,34 +109,12 @@ const GoalCard = memo(
             <Typography variant="caption" sx={{ color: 'text.secondary' }}>
               Inflation: {displayedInflationRate}%
             </Typography>
-          </Box>
-
-          {/* Right section: Duration and progress */}
-          {goal.goalType !== GoalType.RECURRING && (
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                flexShrink: 0,
-              }}
-            >
-              <Typography
-                variant="body2"
-                sx={{ color: 'grey', textAlign: 'center' }}
-              >
+            {goal.goalType !== GoalType.RECURRING && (
+              <Typography variant="caption" display="block" sx={{ color: 'text.secondary', mt: 0.5 }}>
                 {goalDuration}
               </Typography>
-              <Box sx={{ transform: 'scale(0.8)', transformOrigin: 'center' }}>
-                <SemiCircleProgressBar
-                  percentage={progressPercentage}
-                  showPercentValue
-                  strokeWidth={5}
-                  diameter={90}
-                />
-              </Box>
-            </Box>
-          )}
+            )}
+          </Box>
         </Box>
 
         {/* Investment Breakdown Toggle */}
@@ -144,7 +123,10 @@ const GoalCard = memo(
             sx={{
               display: 'flex',
               alignItems: 'center',
-              mt: 1,
+              mt: 1.5,
+              pt: 1,
+              borderTop: '1px dashed',
+              borderColor: 'divider',
               cursor: 'pointer',
               userSelect: 'none',
             }}
@@ -179,11 +161,12 @@ const GoalCard = memo(
                 sx={{
                   display: 'flex',
                   ml: 2,
-                  height: 6,
+                  height: 5,
                   borderRadius: 1,
                   overflow: 'hidden',
                   flex: 1,
-                  maxWidth: 120,
+                  maxWidth: 100,
+                  opacity: 0.75,
                 }}
               >
                 {investmentSuggestions.map((suggestion, index) => (
@@ -191,8 +174,7 @@ const GoalCard = memo(
                     key={suggestion.investmentName}
                     sx={{
                       flex: suggestion.amount / totalMonthlyInvestment,
-                      backgroundColor:
-                        INVESTMENT_COLORS[index % INVESTMENT_COLORS.length],
+                      backgroundColor: INVESTMENT_COLORS[index % INVESTMENT_COLORS.length],
                     }}
                   />
                 ))}
@@ -203,59 +185,42 @@ const GoalCard = memo(
 
         {/* Expandable Investment Breakdown */}
         <Collapse in={expanded}>
-          <Box
-            sx={{
-              mt: 1.5,
-              pt: 1.5,
-              borderTop: '1px dashed',
-              borderColor: 'divider',
-            }}
-          >
-            <Typography
-              variant="caption"
-              sx={{ color: 'text.secondary', mb: 1, display: 'block' }}
-            >
-              Investment Breakdown (Monthly)
-            </Typography>
-
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-              {investmentSuggestions.map((suggestion, index) => (
+          <Box sx={{ mt: 1, display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {investmentSuggestions.map((suggestion, index) => {
+              const color = INVESTMENT_COLORS[index % INVESTMENT_COLORS.length];
+              const pct = totalMonthlyInvestment > 0
+                ? Math.round((suggestion.amount / totalMonthlyInvestment) * 100)
+                : 0;
+              return (
                 <Chip
                   key={suggestion.investmentName}
-                  size="small"
                   label={
-                    <Box
-                      sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
-                    >
-                      <Box
-                        sx={{
-                          width: 8,
-                          height: 8,
-                          borderRadius: '50%',
-                          backgroundColor:
-                            INVESTMENT_COLORS[index % INVESTMENT_COLORS.length],
-                        }}
-                      />
-                      <span>{suggestion.investmentName}</span>
-                      <Typography
-                        component="span"
-                        sx={{ fontWeight: 'bold', ml: 0.5 }}
-                      >
-                        {formatCurrency(suggestion.amount)}
+                    <Box sx={{ py: 0.25 }}>
+                      <Typography variant="caption" display="block" sx={{ fontWeight: 500, lineHeight: 1.4 }}>
+                        {suggestion.investmentName}
                       </Typography>
+                      <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.5 }}>
+                        <Typography variant="caption" sx={{ fontWeight: 'bold', color, lineHeight: 1.4 }}>
+                          {formatCurrency(Math.round(suggestion.amount))}
+                        </Typography>
+                        <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.65rem' }}>
+                          {pct}%
+                        </Typography>
+                      </Box>
                     </Box>
                   }
                   sx={{
-                    backgroundColor: 'background.paper',
+                    height: 'auto',
+                    borderRadius: 1.5,
+                    backgroundColor: 'background.default',
                     border: '1px solid',
                     borderColor: 'divider',
-                    '& .MuiChip-label': {
-                      px: 1,
-                    },
+                    borderLeft: `3px solid ${color}`,
+                    '& .MuiChip-label': { px: 1.25 },
                   }}
                 />
-              ))}
-            </Box>
+              );
+            })}
           </Box>
         </Collapse>
 
@@ -265,8 +230,8 @@ const GoalCard = memo(
           onClick={() => setIsEditing(true)}
           sx={{
             position: 'absolute',
-            top: 4,
-            right: 4,
+            top: 8,
+            right: 8,
             color: 'primary.main',
             opacity: 0.6,
             '&:hover': {
@@ -287,8 +252,8 @@ const GoalCard = memo(
           onClick={handleDelete}
           sx={{
             position: 'absolute',
-            top: 36,
-            right: 4,
+            top: 40,
+            right: 8,
             color: 'error.main',
             opacity: 0.6,
             '&:hover': {

--- a/src/pages/Planner/components/GoalGrowthChart/index.tsx
+++ b/src/pages/Planner/components/GoalGrowthChart/index.tsx
@@ -33,7 +33,7 @@ const GoalGrowthChart = ({ sips, goals, allSuggestions, goalWiseSuggestions }: P
       <Box sx={{ py: 4, textAlign: 'center' }} aria-label="Portfolio growth projection chart">
         <Typography variant="body2" color="text.secondary">
           {sips.length === 0
-            ? 'Log your SIPs above to see portfolio growth.'
+            ? 'Log your SIPs in the Investment Plan tab to see portfolio growth.'
             : 'Add one-time financial goals to see growth with withdrawals.'}
         </Typography>
       </Box>

--- a/src/pages/Planner/components/InvestmentSuggestions/index.test.tsx
+++ b/src/pages/Planner/components/InvestmentSuggestions/index.test.tsx
@@ -4,16 +4,9 @@ import InvestmentSuggestionsBox from './index';
 import { TermType } from '../../../../types/enums';
 import { InvestmentAllocationsType } from '../../../../domain/InvestmentOptions';
 
-// Mock child components
 vi.mock('../GoalCard/components/InvestmentTracker', () => ({
   default: function MockInvestmentTracker() {
     return <div data-testid="investment-tracker">Investment Tracker</div>;
-  },
-}));
-
-vi.mock('../InvestmentSuggestionsDoughnutChart', () => ({
-  default: function MockDoughnutChart() {
-    return <div data-testid="doughnut-chart">Doughnut Chart</div>;
   },
 }));
 
@@ -34,15 +27,14 @@ vi.mock('../InvestmentAllocations', async () => {
   };
 });
 
-vi.mock('../InvestmentPieChart', () => ({
-  default: function MockPieChart() {
-    return <div data-testid="pie-chart">Pie Chart</div>;
-  },
-}));
-
 vi.mock('../CustomLegend', () => ({
-  default: function MockCustomLegend() {
-    return <div data-testid="custom-legend">Custom Legend</div>;
+  default: function MockCustomLegend({ label, onCustomize }: { label?: string; onCustomize?: () => void }) {
+    return (
+      <div data-testid="custom-legend">
+        {label && <span>{label}</span>}
+        {onCustomize && <button onClick={onCustomize}>tune</button>}
+      </div>
+    );
   },
 }));
 
@@ -98,7 +90,7 @@ describe('InvestmentSuggestionsBox', () => {
     jest.clearAllMocks();
   });
 
-  it('should render Suggestions and Investment Tracker tabs', () => {
+  it('renders both Allocation Plan and Investment Tracker sections simultaneously', () => {
     render(
       <InvestmentSuggestionsBox
         dispatch={mockDispatch}
@@ -107,37 +99,36 @@ describe('InvestmentSuggestionsBox', () => {
         investmentLogs={[]}
       />
     );
-    expect(screen.getByRole('tab', { name: /allocation plan/i })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: /investment tracker/i })).toBeInTheDocument();
-  });
-
-  it('should show suggestions tab content by default', () => {
-    render(
-      <InvestmentSuggestionsBox
-        dispatch={mockDispatch}
-        investmentAllocations={mockInvestmentAllocations}
-        investmentBreakdownBasedOnTermType={mockInvestmentBreakdown}
-        investmentLogs={[]}
-      />
-    );
-    expect(screen.getByText(/Investments for Short Term/i)).toBeInTheDocument();
-    expect(screen.getByText(/Investments for Long Term/i)).toBeInTheDocument();
-  });
-
-  it('should show Investment Tracker tab when clicked', () => {
-    render(
-      <InvestmentSuggestionsBox
-        dispatch={mockDispatch}
-        investmentAllocations={mockInvestmentAllocations}
-        investmentBreakdownBasedOnTermType={mockInvestmentBreakdown}
-        investmentLogs={[]}
-      />
-    );
-    fireEvent.click(screen.getByRole('tab', { name: /investment tracker/i }));
+    expect(screen.getByText(/allocation plan/i)).toBeInTheDocument();
     expect(screen.getByTestId('investment-tracker')).toBeInTheDocument();
   });
 
-  it('should open modal when customize button is clicked', () => {
+  it('shows term type headings in the allocation column', () => {
+    render(
+      <InvestmentSuggestionsBox
+        dispatch={mockDispatch}
+        investmentAllocations={mockInvestmentAllocations}
+        investmentBreakdownBasedOnTermType={mockInvestmentBreakdown}
+        investmentLogs={[]}
+      />
+    );
+    expect(screen.getByText(TermType.SHORT_TERM)).toBeInTheDocument();
+    expect(screen.getByText(TermType.LONG_TERM)).toBeInTheDocument();
+  });
+
+  it('renders the Investment Tracker without any tab click', () => {
+    render(
+      <InvestmentSuggestionsBox
+        dispatch={mockDispatch}
+        investmentAllocations={mockInvestmentAllocations}
+        investmentBreakdownBasedOnTermType={mockInvestmentBreakdown}
+        investmentLogs={[]}
+      />
+    );
+    expect(screen.getByTestId('investment-tracker')).toBeInTheDocument();
+  });
+
+  it('opens modal when customize button is clicked', () => {
     render(
       <InvestmentSuggestionsBox
         dispatch={mockDispatch}
@@ -151,7 +142,7 @@ describe('InvestmentSuggestionsBox', () => {
     expect(screen.getByTestId('investment-allocations')).toBeInTheDocument();
   });
 
-  it('should close modal when handleSubmit is called', () => {
+  it('closes modal when handleSubmit is called', () => {
     render(
       <InvestmentSuggestionsBox
         dispatch={mockDispatch}
@@ -166,7 +157,7 @@ describe('InvestmentSuggestionsBox', () => {
     fireEvent.click(screen.getByText('Submit'));
   });
 
-  it('should filter out term types with no investment suggestions', () => {
+  it('filters out term types with no investment suggestions', () => {
     const emptyBreakdown = [
       {
         termType: TermType.SHORT_TERM,
@@ -197,11 +188,11 @@ describe('InvestmentSuggestionsBox', () => {
         investmentLogs={[]}
       />
     );
-    expect(screen.queryByText(/Investments for Short Term/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/Investments for Long Term/i)).toBeInTheDocument();
+    expect(screen.queryByText(TermType.SHORT_TERM)).not.toBeInTheDocument();
+    expect(screen.getByText(TermType.LONG_TERM)).toBeInTheDocument();
   });
 
-  it('should show empty state when all breakdowns have no suggestions', () => {
+  it('shows empty state when all breakdowns have no suggestions', () => {
     const emptyBreakdown = [
       {
         termType: TermType.SHORT_TERM,

--- a/src/pages/Planner/components/InvestmentSuggestions/index.tsx
+++ b/src/pages/Planner/components/InvestmentSuggestions/index.tsx
@@ -3,26 +3,19 @@ import {
   Typography,
   Grid2 as Grid,
   Modal,
-  Button,
-  Tab,
-  Tabs,
-  Tooltip,
+  Divider,
 } from '@mui/material';
 import { PlannerDataAction } from '../../../../store/plannerDataReducer';
 import { TermType } from '../../../../types/enums';
 import { GoalWiseInvestmentSuggestions } from '../../hooks/useInvestmentCalculator';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import AllocationTour from '../AllocationTour';
-import InvestmentSuggestionsDoughnutChart from '../InvestmentSuggestionsDoughnutChart';
 import InvestmentAllocations from '../InvestmentAllocations';
-import InvestmentPieChart from '../InvestmentPieChart';
 import CustomLegend from '../CustomLegend';
 import { StyledBox } from '../../../../components/StyledBox';
 import { InvestmentAllocationsType } from '../../../../domain/InvestmentOptions';
 import { SIPEntry } from '../../../../types/investmentLog';
 import { InvestmentSuggestion } from '../../../../types/planner';
-import { FinancialGoal } from '../../../../domain/FinancialGoals';
-import { GoalSuggestion } from '../../../../domain/investmentLog';
 import InvestmentTracker from '../GoalCard/components/InvestmentTracker';
 
 export type InvestmentBreakdownBasedOnTermType = {
@@ -35,15 +28,12 @@ const InvestmentSuggestionsBox = ({
   dispatch,
   investmentBreakdownBasedOnTermType,
   investmentLogs = [],
-  goals = [],
 }: {
   dispatch: React.Dispatch<PlannerDataAction>;
   investmentAllocations: InvestmentAllocationsType;
   investmentBreakdownBasedOnTermType: InvestmentBreakdownBasedOnTermType[];
   investmentLogs: SIPEntry[];
-  goals?: FinancialGoal[];
 }) => {
-  const [activeTab, setActiveTab] = useState<0 | 1>(0);
   const [termTypeModal, setTermTypeModal] = useState<TermType | null>(null);
   const [runAllocationTour, setRunAllocationTour] = useState(false);
   const hasShownAllocationTourRef = useRef(false);
@@ -61,20 +51,9 @@ const InvestmentSuggestionsBox = ({
   const handleClose = () => setTermTypeModal(null);
   const handleSubmit = () => setTermTypeModal(null);
 
-  const goalWiseSuggestions: GoalSuggestion[] = useMemo(() => {
-    return investmentBreakdownBasedOnTermType
-      .flatMap((term) => term.investmentBreakdown)
-      .flatMap((b) => {
-        const goal = goals.find((g) => g.getGoalName() === b.goalName);
-        if (!goal || b.investmentSuggestions.length === 0) return [];
-        return [{ goalStartDate: goal.getInvestmentStartDate(), goalTargetDate: goal.getTargetDate(), suggestions: b.investmentSuggestions }];
-      });
-  }, [investmentBreakdownBasedOnTermType, goals]);
-
   const aggregatedSuggestions: InvestmentSuggestion[] = useMemo(() => {
     const totals: Record<string, number> = {};
     const rates: Record<string, number> = {};
-
     for (const term of investmentBreakdownBasedOnTermType) {
       for (const goalBreakdown of term.investmentBreakdown) {
         for (const suggestion of goalBreakdown.investmentSuggestions) {
@@ -84,7 +63,6 @@ const InvestmentSuggestionsBox = ({
         }
       }
     }
-
     return Object.entries(totals).map(([name, amount]) => ({
       investmentName: name,
       amount: Math.round(amount),
@@ -100,120 +78,70 @@ const InvestmentSuggestionsBox = ({
   return (
     <>
       <StyledBox mb={2} className="investment-plan-box">
-        <Tabs
-          value={activeTab}
-          onChange={(_, v) => setActiveTab(v as 0 | 1)}
-          sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
-        >
-          <Tab label="Allocation Plan" />
-          <Tab label="Investment Tracker" />
-        </Tabs>
-
-        {/* Tab 0: Suggestions */}
-        <Box role="tabpanel" hidden={activeTab !== 0}>
-          <Grid container>
-            <Grid size={12}>
-              {visibleTerms.map((term) => (
-                <Box key={term.termType} mb={2}>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      flexDirection: 'row',
-                      justifyContent: 'space-between',
-                    }}
-                  >
-                    <Typography variant="h6" fontWeight="bold">
-                      Investments for {term.termType}
-                    </Typography>
-                    <Tooltip title="Customize allocation" arrow>
-                      <Button
-                        onClick={() => setTermTypeModal(term.termType)}
-                        sx={{ color: 'green', px: 0 }}
-                        className="customize-button"
-                      >
-                        <span className="material-symbols-rounded">tune</span>
-                      </Button>
-                    </Tooltip>
-                  </Box>
-                  <Grid container justifyContent="center" alignItems="center">
-                    <>
-                      <Grid
-                        size={{ xs: 0, sm: 0, md: 6, lg: 3.5 }}
-                        display={{ xs: 'none', sm: 'none', md: 'flex', lg: 'flex' }}
-                        justifyContent="center"
-                        alignItems="center"
-                      >
-                        <InvestmentPieChart
-                          allocations={investmentAllocations[term.termType]}
-                        />
-                      </Grid>
-                      <Grid
-                        size={{ xs: 0, sm: 0, md: 0, lg: 1 }}
-                        display={{ xs: 'none', sm: 'none', md: 'none', lg: 'flex' }}
-                        justifyContent="center"
-                        alignItems="center"
-                      >
-                        <span
-                          className="material-symbols-rounded"
-                          style={{ fontSize: '80px' }}
-                        >
-                          double_arrow
-                        </span>
-                      </Grid>
-                    </>
-                    <Grid
-                      size={{ xs: 0, sm: 0, md: 0, lg: 3.5 }}
-                      display={{ xs: 'none', sm: 'none', md: 'none', lg: 'flex' }}
-                      justifyContent="center"
-                      alignItems="center"
-                    >
-                      <InvestmentSuggestionsDoughnutChart
-                        suggestions={term.investmentBreakdown}
-                      />
-                    </Grid>
-                    <Grid
-                      size={{ xs: 12, sm: 12, md: 6, lg: 4 }}
-                      display={{ xs: 'flex', sm: 'flex', md: 'flex', lg: 'flex' }}
-                      justifyContent="center"
-                      alignItems="center"
-                    >
-                      <CustomLegend suggestions={term.investmentBreakdown} />
-                    </Grid>
-                  </Grid>
-                </Box>
-              ))}
-              {visibleTerms.length === 0 && (
-                <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
-                  Add financial goals to see investment suggestions.
-                </Typography>
-              )}
-            </Grid>
-          </Grid>
-        </Box>
-
-        {/* Tab 1: Investment Tracker */}
-        <Box role="tabpanel" hidden={activeTab !== 1}>
-          {aggregatedSuggestions.length === 0 ? (
-            <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
-              Add financial goals to see investment types to track against.
+        <Grid container spacing={3}>
+          {/* Left: Allocation Plan */}
+          <Grid
+            size={{ xs: 12, md: 5 }}
+            sx={{
+              borderRight: { md: '1px solid' },
+              borderColor: { md: 'divider' },
+              pr: { md: 3 },
+            }}
+          >
+            <Typography
+              variant="overline"
+              color="text.secondary"
+              sx={{ letterSpacing: 1.2, display: 'block', mb: 1.5 }}
+            >
+              Allocation Plan
             </Typography>
-          ) : (
-            <InvestmentTracker
-              investmentSuggestions={aggregatedSuggestions}
-              sips={investmentLogs}
-              goals={goals}
-              dispatch={dispatch}
-              goalWiseSuggestions={goalWiseSuggestions}
-            />
-          )}
-        </Box>
 
+            {visibleTerms.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                Add financial goals to see investment suggestions.
+              </Typography>
+            ) : (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                {visibleTerms.map((term, i) => (
+                  <Box key={term.termType}>
+                    {i > 0 && <Divider sx={{ mb: 2 }} />}
+                    <CustomLegend
+                      suggestions={term.investmentBreakdown}
+                      label={term.termType}
+                      onCustomize={() => setTermTypeModal(term.termType)}
+                    />
+                  </Box>
+                ))}
+              </Box>
+            )}
+          </Grid>
+
+          {/* Right: Investment Tracker */}
+          <Grid size={{ xs: 12, md: 7 }}>
+            <Typography
+              variant="overline"
+              color="text.secondary"
+              sx={{ letterSpacing: 1.2, display: 'block', mb: 1.5 }}
+            >
+              Investment Tracker
+            </Typography>
+
+            {aggregatedSuggestions.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                Add financial goals to see investment types to track against.
+              </Typography>
+            ) : (
+              <InvestmentTracker
+                investmentSuggestions={aggregatedSuggestions}
+                sips={investmentLogs}
+                dispatch={dispatch}
+              />
+            )}
+          </Grid>
+        </Grid>
       </StyledBox>
 
-      <AllocationTour
-        run={runAllocationTour}
-        onDone={() => setRunAllocationTour(false)}
-      />
+      <AllocationTour run={runAllocationTour} onDone={() => setRunAllocationTour(false)} />
 
       <Modal
         open={termTypeModal !== null}

--- a/src/pages/Planner/components/Pagetour/index.test.tsx
+++ b/src/pages/Planner/components/Pagetour/index.test.tsx
@@ -89,15 +89,15 @@ describe('PageTour', () => {
     expect(onDone).toHaveBeenCalledTimes(1);
   });
 
-  it('shows all 7 steps on desktop', () => {
+  it('shows all 5 steps on desktop', () => {
     render(<PageTour run={true} />);
     act(() => {
       vi.runAllTimers();
     });
-    expect(lastInstance!.stepCount).toBe(7);
+    expect(lastInstance!.stepCount).toBe(5);
   });
 
-  it('shows 6 steps on mobile (desktop-only goal box step excluded)', () => {
+  it('shows 5 steps on mobile (no desktop-only steps)', () => {
     Object.defineProperty(window, 'innerWidth', {
       value: 400,
       writable: true,
@@ -107,6 +107,6 @@ describe('PageTour', () => {
     act(() => {
       vi.runAllTimers();
     });
-    expect(lastInstance!.stepCount).toBe(6);
+    expect(lastInstance!.stepCount).toBe(5);
   });
 });

--- a/src/pages/Planner/components/Pagetour/index.tsx
+++ b/src/pages/Planner/components/Pagetour/index.tsx
@@ -6,28 +6,16 @@ const isMobile = () => window.innerWidth < 600;
 
 const allSteps = [
   {
-    element: '.target-box',
+    element: '.stat-total-target',
     desktopOnly: false,
     content:
-      'Your total financial target — the inflation-adjusted sum of all your goals. It updates automatically as you add or edit goals.',
+      'Your total financial target — the inflation-adjusted sum of all your goals. The monthly required and investing tiles show how your SIPs compare to the plan.',
   },
   {
-    element: '.add-goals-button',
+    element: '.goals-drawer-button',
     desktopOnly: false,
     content:
-      'Add a goal here. Give it a name, target amount, and deadline — the app automatically classifies it as short (≤3 yr), medium (3–7 yr), or long term (7+ yr).',
-  },
-  {
-    element: '.financial-goals-box',
-    desktopOnly: true,
-    content:
-      'All your goals at a glance. Each card shows the goal name, target date, inflation-adjusted amount, and how much you have invested so far.',
-  },
-  {
-    element: '.financial-progress-box',
-    desktopOnly: false,
-    content:
-      "Goals grouped by time horizon. Each bar shows the percentage of that term's total target you've already covered with current investments.",
+      'Open your goals here. Each card shows the goal name, target date, inflation-adjusted amount, and monthly SIP breakdown. Add new goals from inside this panel.',
   },
   {
     element: '.investment-plan-box',

--- a/src/pages/Planner/components/PlannerStatStrip/index.tsx
+++ b/src/pages/Planner/components/PlannerStatStrip/index.tsx
@@ -1,0 +1,145 @@
+import { Box, Chip, Typography } from '@mui/material';
+import { FinancialGoal } from '../../../../domain/FinancialGoals';
+import { TermType } from '../../../../types/enums';
+import { formatCurrency } from '../../../../types/util';
+
+export type PlannerStatStripProps = {
+  targetAmount: number;
+  totalRequired: number;
+  totalInvesting: number;
+  financialGoals?: FinancialGoal[];
+  onGoalsClick?: () => void;
+  onAddGoal?: () => void;
+};
+
+const TERM_CONFIG: { type: TermType; label: string; color: string }[] = [
+  { type: TermType.SHORT_TERM, label: 'Short', color: '#ED6C02' },
+  { type: TermType.MEDIUM_TERM, label: 'Mid', color: '#0288D1' },
+  { type: TermType.LONG_TERM, label: 'Long', color: '#2E7D32' },
+];
+
+const StatTile = ({
+  label,
+  value,
+  caption,
+  valueColor,
+  className,
+  children,
+}: {
+  label: string;
+  value: string;
+  caption?: string;
+  valueColor?: string;
+  className?: string;
+  children?: React.ReactNode;
+}) => (
+  <Box
+    className={className}
+    sx={{
+      flex: 1,
+      p: 2,
+      border: '1px solid',
+      borderColor: 'divider',
+      borderRadius: 1.5,
+      backgroundColor: 'background.paper',
+    }}
+  >
+    <Typography variant="overline" color="text.secondary" sx={{ fontSize: '0.65rem', letterSpacing: 1.2, display: 'block', lineHeight: 1.4 }}>
+      {label}
+    </Typography>
+    <Typography variant="h6" fontWeight="bold" color={valueColor ?? 'text.primary'} sx={{ mt: 0.5 }}>
+      {value}
+    </Typography>
+    {caption && (
+      <Typography variant="caption" color="text.secondary">
+        {caption}
+      </Typography>
+    )}
+    {children}
+  </Box>
+);
+
+const PlannerStatStrip = ({ targetAmount, totalRequired, totalInvesting, financialGoals, onGoalsClick, onAddGoal }: PlannerStatStripProps) => {
+  const isOnTrack = totalInvesting >= totalRequired;
+  const investingColor = isOnTrack ? 'success.main' : totalInvesting > 0 ? 'warning.main' : 'text.secondary';
+  const investingCaption = totalInvesting === 0
+    ? 'No SIPs logged yet'
+    : isOnTrack
+    ? 'On track'
+    : `${formatCurrency(totalRequired - totalInvesting)} short`;
+
+  const termChips = TERM_CONFIG
+    .map(({ type, label, color }) => ({
+      label,
+      color,
+      count: financialGoals?.filter((g) => g.getTermType() === type).length ?? 0,
+    }))
+    .filter(({ count }) => count > 0);
+
+  return (
+    <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: { xs: 'wrap', sm: 'nowrap' } }}>
+      <StatTile
+        className="stat-total-target"
+        label="Total Goal Target"
+        value={formatCurrency(targetAmount)}
+        valueColor="primary.main"
+      >
+        <Box
+          className="goals-drawer-button"
+          sx={{ display: 'flex', gap: 0.75, mt: 1, flexWrap: 'wrap', alignItems: 'center' }}
+        >
+          {onGoalsClick && termChips.map(({ label, color, count }) => (
+            <Chip
+              key={label}
+              size="small"
+              label={`${label} · ${count}`}
+              onClick={onGoalsClick}
+              sx={{
+                fontSize: '0.68rem',
+                height: 20,
+                backgroundColor: `${color}18`,
+                color,
+                border: `1px solid ${color}40`,
+                cursor: 'pointer',
+                '& .MuiChip-label': { px: 1 },
+                '&:hover': { backgroundColor: `${color}28` },
+              }}
+            />
+          ))}
+          {onAddGoal && (
+            <Chip
+              size="small"
+              label="+ Add Goal"
+              onClick={onAddGoal}
+              className="add-goals-button"
+              sx={{
+                fontSize: '0.68rem',
+                height: 20,
+                backgroundColor: 'transparent',
+                color: 'primary.main',
+                border: '1px dashed',
+                borderColor: 'primary.main',
+                cursor: 'pointer',
+                '& .MuiChip-label': { px: 1 },
+                '&:hover': { backgroundColor: 'primary.main', color: 'primary.contrastText' },
+              }}
+            />
+          )}
+        </Box>
+      </StatTile>
+      <StatTile
+        label="Monthly Required"
+        value={formatCurrency(totalRequired)}
+        caption="/month across all goals"
+      />
+      <StatTile
+        label="Monthly Investing"
+        value={formatCurrency(totalInvesting)}
+        caption={investingCaption}
+        valueColor={investingColor}
+      />
+    </Box>
+  );
+};
+
+export default PlannerStatStrip;

--- a/src/pages/Planner/components/PrintableReport/index.tsx
+++ b/src/pages/Planner/components/PrintableReport/index.tsx
@@ -2,14 +2,12 @@ import React from 'react';
 import dayjs from 'dayjs';
 import { PlannerData } from '../../../../domain/PlannerData';
 import { InvestmentBreakdownBasedOnTermType } from '../InvestmentSuggestions';
-import { TermTypeWiseProgressData } from '../TermwiseProgressBox';
 import { buildPortfolioWithdrawalSeries } from '../../../../domain/investmentLog';
 import { InvestmentSuggestion } from '../../../../types/planner';
 type PrintableReportProps = {
   plannerData: PlannerData;
   selectedDate: string;
   investmentBreakdownBasedOnTermType: InvestmentBreakdownBasedOnTermType[];
-  termTypeWiseProgressData: TermTypeWiseProgressData[];
   printRef: React.RefObject<HTMLDivElement | null>;
 };
 
@@ -64,7 +62,6 @@ const PrintableReport = ({
   plannerData,
   selectedDate,
   investmentBreakdownBasedOnTermType,
-  termTypeWiseProgressData,
   printRef,
 }: PrintableReportProps) => {
   const hasGoals = plannerData.financialGoals.length > 0;
@@ -244,40 +241,7 @@ const PrintableReport = ({
             )}
           </div>
 
-          {/* ── Section 4: Term-wise Progress Summary ── */}
-          <div style={sectionStyle}>
-            <h2 style={headingStyle}>Term-wise Progress Summary</h2>
-            {termTypeWiseProgressData.length === 0 ? (
-              <p style={emptyStyle}>No progress data available.</p>
-            ) : (
-              <table style={tableStyle}>
-                <thead>
-                  <tr>
-                    <th style={thStyle}>Term</th>
-                    <th style={thStyle}>Goals</th>
-                    <th style={thStyle}>Target Amount</th>
-                    <th style={thStyle}>Progress</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {termTypeWiseProgressData.map((item, i) => (
-                    <tr key={i} style={{ backgroundColor: i % 2 === 0 ? '#fff' : '#fafafa' }}>
-                      <td style={tdStyle}>{item.termType}</td>
-                      <td style={tdStyle}>
-                        {item.termTypeWiseData.goalNames.join(', ')}
-                      </td>
-                      <td style={tdStyle}>
-                        {formatAmount(item.termTypeWiseData.termTypeSum)}
-                      </td>
-                      <td style={tdStyle}>{item.termTypeWiseData.progressPercent}%</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            )}
-          </div>
-
-          {/* ── Section 5: Growth Projection Summary ── */}
+          {/* ── Section 4: Growth Projection Summary ── */}
           <div style={sectionStyle}>
             <h2 style={headingStyle}>Growth Projection Summary</h2>
             {!hasProjection ? (

--- a/src/pages/Planner/hooks/usePdfExport.ts
+++ b/src/pages/Planner/hooks/usePdfExport.ts
@@ -16,31 +16,16 @@ function addCanvasToMultiPagePdf(
   const pdfWidth = doc.internal.pageSize.getWidth();
   const pdfHeight = doc.internal.pageSize.getHeight();
 
-  const canvasWidth = canvas.width;
-  const canvasHeight = canvas.height;
-
-  // Scale canvas width to fit the PDF page width
   const imgWidth = pdfWidth;
-  const imgHeight = (canvasHeight / canvasWidth) * imgWidth;
+  const imgHeight = (canvas.height / canvas.width) * imgWidth;
 
+  // Encode once — reused across all pages
+  const imgData = canvas.toDataURL('image/jpeg', 0.88);
   const pageCount = Math.ceil(imgHeight / pdfHeight);
 
   for (let page = 0; page < pageCount; page++) {
-    if (page > 0) {
-      doc.addPage();
-    }
-
-    // Y offset in the scaled image coordinates
-    const yOffset = -(page * pdfHeight);
-
-    doc.addImage(
-      canvas.toDataURL('image/png'),
-      'PNG',
-      0,
-      yOffset,
-      imgWidth,
-      imgHeight,
-    );
+    if (page > 0) doc.addPage();
+    doc.addImage(imgData, 'JPEG', 0, -(page * pdfHeight), imgWidth, imgHeight);
   }
 }
 
@@ -66,7 +51,7 @@ const usePdfExport = (): UsePdfExportReturn => {
       el.style.display = 'block';
 
       const canvas = await html2canvas(el, {
-        scale: 2,
+        scale: 1.5,
         useCORS: true,
         logging: false,
         backgroundColor: '#ffffff',

--- a/src/pages/Planner/index.test.tsx
+++ b/src/pages/Planner/index.test.tsx
@@ -22,19 +22,17 @@ vi.mock('./components/Pagetour', () => ({
   },
 }));
 
-vi.mock('./components/TargetBox', () => ({
-  default: function MockTargetBox({ setShowDrawer }: { setShowDrawer: (v: boolean) => void }) {
+vi.mock('./components/PlannerStatStrip', () => ({
+  default: function MockPlannerStatStrip({ onGoalsClick, onAddGoal, financialGoals }: { onGoalsClick?: () => void; onAddGoal?: () => void; financialGoals?: { getTermType: () => string }[] }) {
+    const count = financialGoals?.length ?? 0;
     return (
-      <div data-testid="target-box">
-        <button data-testid="open-drawer" onClick={() => setShowDrawer(true)} />
+      <div data-testid="planner-stat-strip">
+        {onGoalsClick && count > 0 && (
+          <button onClick={onGoalsClick}>{count} Goal{count !== 1 ? 's' : ''}</button>
+        )}
+        {onAddGoal && <button onClick={onAddGoal}>+ Add Goal</button>}
       </div>
     );
-  },
-}));
-
-vi.mock('./components/TermwiseProgressBox', () => ({
-  default: function MockTermWiseProgressBox() {
-    return <div data-testid="termwise-progress" />;
   },
 }));
 
@@ -50,6 +48,12 @@ vi.mock('./components/GoalBox', () => ({
   },
 }));
 
+vi.mock('./components/GoalGrowthChart', () => ({
+  default: function MockGoalGrowthChart() {
+    return <div data-testid="goal-growth-chart" />;
+  },
+}));
+
 vi.mock('./components/PrintableReport', () => ({
   default: function MockPrintableReport() {
     return <div data-testid="printable-report" />;
@@ -59,6 +63,12 @@ vi.mock('./components/PrintableReport', () => ({
 vi.mock('../CongratulationsPage', () => ({
   default: function MockCongratulationsPage() {
     return <div data-testid="congratulations" />;
+  },
+}));
+
+vi.mock('../Home/components/AddGoalPopup', () => ({
+  default: function MockAddGoalPopup() {
+    return null;
   },
 }));
 
@@ -118,16 +128,15 @@ describe('Planner', () => {
     vi.clearAllMocks();
   });
 
-  it('renders CongratulationsPage when there are no goals (both counts are 0)', () => {
+  it('does not show CongratulationsPage when there are no goals', () => {
     renderPlanner({ plannerData: new PlannerData() });
-    expect(screen.getByTestId('congratulations')).toBeInTheDocument();
+    expect(screen.queryByTestId('congratulations')).not.toBeInTheDocument();
   });
 
-  it('renders TargetBox, TermWiseProgressBox, and InvestmentSuggestions when a future goal exists', () => {
+  it('renders stat strip and investment suggestions when a future goal exists', () => {
     const plannerData = new PlannerData([makeGoal()]);
     renderPlanner({ plannerData });
-    expect(screen.getByTestId('target-box')).toBeInTheDocument();
-    expect(screen.getByTestId('termwise-progress')).toBeInTheDocument();
+    expect(screen.getByTestId('planner-stat-strip')).toBeInTheDocument();
     expect(screen.getByTestId('investment-suggestions')).toBeInTheDocument();
   });
 
@@ -161,10 +170,9 @@ describe('Planner', () => {
     expect(screen.getByTestId('printable-report')).toBeInTheDocument();
   });
 
-  it('renders PrintableReport even in CongratulationsPage state', () => {
+  it('renders PrintableReport even with no goals', () => {
     renderPlanner({ plannerData: new PlannerData() });
     expect(screen.getByTestId('printable-report')).toBeInTheDocument();
-    expect(screen.getByTestId('congratulations')).toBeInTheDocument();
   });
 
   it('renders CongratulationsPage when all goals have past target dates', () => {
@@ -182,18 +190,27 @@ describe('Planner', () => {
   it('handleChange: changing the date picker updates state without error', () => {
     const plannerData = new PlannerData([makeGoal()]);
     renderPlanner({ plannerData });
-    // Fires handleChange (covers line 49: setSelectedDate)
     fireEvent.change(screen.getByTestId('date-picker'), {
       target: { value: '2026-06-01' },
     });
-    expect(screen.getByTestId('target-box')).toBeInTheDocument();
+    expect(screen.getByTestId('planner-stat-strip')).toBeInTheDocument();
   });
 
-  it('setShowDrawerCallback: clicking open-drawer shows the Goals drawer', () => {
+  it('renders Investment Plan and Portfolio tab labels when a future goal exists', () => {
     const plannerData = new PlannerData([makeGoal()]);
     renderPlanner({ plannerData });
-    // Fires setShowDrawerCallback (covers line 166: setShowDrawer)
-    fireEvent.click(screen.getByTestId('open-drawer'));
-    expect(screen.getByText('Goals')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Investment Plan' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Portfolio' })).toBeInTheDocument();
+  });
+
+  it('renders Add Goal button in stat strip', () => {
+    renderPlanner({ plannerData: new PlannerData([makeGoal()]) });
+    expect(screen.getByRole('button', { name: /add goal/i })).toBeInTheDocument();
+  });
+
+  it('renders term goal chips in stat strip when goals exist', () => {
+    const plannerData = new PlannerData([makeGoal()]);
+    renderPlanner({ plannerData });
+    expect(screen.getByTestId('planner-stat-strip')).toBeInTheDocument();
   });
 });

--- a/src/pages/Planner/index.tsx
+++ b/src/pages/Planner/index.tsx
@@ -3,12 +3,13 @@ import {
   Grid2 as Grid,
   Box,
   Typography,
+  Tab,
+  Tabs,
   Drawer,
   IconButton,
   InputAdornment,
   useMediaQuery,
 } from '@mui/material';
-import CloseIcon from '@mui/icons-material/Close';
 import { CalendarIcon } from '@mui/x-date-pickers';
 import dayjs, { Dayjs } from 'dayjs';
 import DatePicker from '../../components/DatePicker';
@@ -20,15 +21,15 @@ import { TermType } from '../../types/enums';
 import useInvestmentCalculator from './hooks/useInvestmentCalculator';
 import { PlannerData } from '../../domain/PlannerData';
 import { PlannerDataAction } from '../../store/plannerDataReducer';
-import TermWiseProgressBox, {
-  TermTypeWiseProgressData,
-} from './components/TermwiseProgressBox';
 import GoalBox from './components/GoalBox';
 import { StyledBox } from '../../components/StyledBox';
 import PageTour from './components/Pagetour';
-import TargetBox from './components/TargetBox';
 import CongratulationsPage from '../CongratulationsPage';
 import PrintableReport from './components/PrintableReport';
+import PlannerStatStrip from './components/PlannerStatStrip';
+import GoalGrowthChart from './components/GoalGrowthChart';
+import AddGoalPopup from '../Home/components/AddGoalPopup';
+import { GoalSuggestion } from '../../domain/investmentLog';
 
 type PlannerProps = {
   plannerData: PlannerData;
@@ -39,11 +40,20 @@ type PlannerProps = {
   onTourDone?: () => void;
 };
 
-const Planner = ({ plannerData, dispatch, headerRight, printRef: externalPrintRef, runTour = false, onTourDone }: PlannerProps) => {
+const Planner = ({
+  plannerData,
+  dispatch,
+  headerRight,
+  printRef: externalPrintRef,
+  runTour = false,
+  onTourDone,
+}: PlannerProps) => {
   const internalPrintRef = useRef<HTMLDivElement>(null);
   const printRef = externalPrintRef ?? internalPrintRef;
   const [selectedDate, setSelectedDate] = useState<string>(dayjs().toString());
-  const [showDrawer, setShowDrawer] = useState(false);
+  const [activeTab, setActiveTab] = useState<0 | 1>(0);
+  const [showGoalsDrawer, setShowGoalsDrawer] = useState(false);
+  const [isAddGoalOpen, setIsAddGoalOpen] = useState(false);
 
   const handleChange = useCallback((value: Dayjs | null) => {
     setSelectedDate(value!.toString());
@@ -58,112 +68,89 @@ const Planner = ({ plannerData, dispatch, headerRight, printRef: externalPrintRe
     [plannerData.financialGoals],
   );
 
-  const { calculateInvestmentNeededForGoals } =
-    useInvestmentCalculator(plannerData);
+  const { calculateInvestmentNeededForGoals } = useInvestmentCalculator(plannerData);
 
   const investmentBreakdownForAllGoals = useMemo(
     () => calculateInvestmentNeededForGoals(plannerData, selectedDate),
     [calculateInvestmentNeededForGoals, plannerData, selectedDate],
   );
 
-  const investmentBreakdownBasedOnTermType: InvestmentBreakdownBasedOnTermType[] =
-    useMemo(() => {
-      const result: InvestmentBreakdownBasedOnTermType[] = [];
-      
-      [TermType.SHORT_TERM, TermType.MEDIUM_TERM, TermType.LONG_TERM].forEach(
-        (termType) => {
-          const goalsForTerm = plannerData.financialGoals.filter(
-            (goal) => goal.getTermType() === termType,
-          );
-
-          if (goalsForTerm.length > 0) {
-            const goalNames = goalsForTerm.map((goal) => goal.goalName);
-
-            const investmentBreakDownPerTerm =
-              investmentBreakdownForAllGoals.filter((ib) =>
-                goalNames.includes(ib.goalName),
-              );
-
-            result.push({
-              termType,
-              investmentBreakdown: investmentBreakDownPerTerm,
-            });
-          }
-        },
+  const investmentBreakdownBasedOnTermType: InvestmentBreakdownBasedOnTermType[] = useMemo(() => {
+    const result: InvestmentBreakdownBasedOnTermType[] = [];
+    [TermType.SHORT_TERM, TermType.MEDIUM_TERM, TermType.LONG_TERM].forEach((termType) => {
+      const goalsForTerm = plannerData.financialGoals.filter(
+        (goal) => goal.getTermType() === termType,
       );
-      
-      return result;
-    }, [plannerData.financialGoals, investmentBreakdownForAllGoals]);
-
-  const termTypeWiseProgressData: TermTypeWiseProgressData[] = useMemo(() => {
-    const result: TermTypeWiseProgressData[] = [];
-
-    [TermType.SHORT_TERM, TermType.MEDIUM_TERM, TermType.LONG_TERM].forEach(
-      (termType) => {
-        const goalsForTerm = plannerData.financialGoals.filter(
-          (goal) => goal.getTermType() === termType,
+      if (goalsForTerm.length > 0) {
+        const goalNames = goalsForTerm.map((goal) => goal.goalName);
+        const investmentBreakDownPerTerm = investmentBreakdownForAllGoals.filter((ib) =>
+          goalNames.includes(ib.goalName),
         );
-
-        if (goalsForTerm.length > 0) {
-          const goalNames = goalsForTerm.map((goal) => goal.goalName);
-
-          const investmentBreakDownPerTerm =
-            investmentBreakdownForAllGoals.filter((ib) =>
-              goalNames.includes(ib.goalName),
-            );
-
-          const termTypeSum = Math.round(
-            goalsForTerm.reduce(
-              (sum, goal) => sum + goal.getInflationAdjustedTargetAmount(),
-              0,
-            ),
-          );
-
-          const progressPercent = Math.round(
-            (investmentBreakDownPerTerm.reduce(
-              (acc, val) => acc + val.currentValue,
-              0,
-            )! /
-              termTypeSum) *
-              100,
-          );
-
-          result.push({
-            termType,
-            termTypeWiseData: {
-              goalNames,
-              termTypeSum,
-              progressPercent,
-            },
-          });
-        }
-      },
-    );
-
+        result.push({ termType, investmentBreakdown: investmentBreakDownPerTerm });
+      }
+    });
     return result;
   }, [plannerData.financialGoals, investmentBreakdownForAllGoals]);
 
-  const completedGoals = useMemo(
-    () =>
-      plannerData.financialGoals.filter((goal) => {
-        return dayjs(selectedDate).isAfter(goal.getTargetDate());
-      }),
-    [plannerData.financialGoals, selectedDate],
+  const aggregatedSuggestions = useMemo(() => {
+    const totals: Record<string, number> = {};
+    const rates: Record<string, number> = {};
+    for (const term of investmentBreakdownBasedOnTermType) {
+      for (const goalBreakdown of term.investmentBreakdown) {
+        for (const suggestion of goalBreakdown.investmentSuggestions) {
+          totals[suggestion.investmentName] = (totals[suggestion.investmentName] ?? 0) + suggestion.amount;
+          rates[suggestion.investmentName] = suggestion.expectedReturnPercentage;
+        }
+      }
+    }
+    return Object.entries(totals).map(([name, amount]) => ({
+      investmentName: name,
+      amount: Math.round(amount),
+      expectedReturnPercentage: rates[name],
+    }));
+  }, [investmentBreakdownBasedOnTermType]);
+
+  const goalWiseSuggestions: GoalSuggestion[] = useMemo(() => {
+    return investmentBreakdownBasedOnTermType
+      .flatMap((term) => term.investmentBreakdown)
+      .flatMap((b) => {
+        const goal = plannerData.financialGoals.find((g) => g.getGoalName() === b.goalName);
+        if (!goal || b.investmentSuggestions.length === 0) return [];
+        return [{
+          goalStartDate: goal.getInvestmentStartDate(),
+          goalTargetDate: goal.getTargetDate(),
+          suggestions: b.investmentSuggestions,
+        }];
+      });
+  }, [investmentBreakdownBasedOnTermType, plannerData.financialGoals]);
+
+  const totalRequired = useMemo(
+    () => Math.round(aggregatedSuggestions.reduce((sum, s) => sum + s.amount, 0)),
+    [aggregatedSuggestions],
   );
 
-  const setShowDrawerCallback = useCallback((value: boolean) => {
-    setShowDrawer(value);
-  }, []);
+  const totalInvesting = useMemo(
+    () => Math.round(plannerData.investmentLogs.reduce((sum, s) => sum + s.monthlyAmount, 0)),
+    [plannerData.investmentLogs],
+  );
+
+  const completedGoals = useMemo(
+    () => plannerData.financialGoals.filter((goal) => dayjs(selectedDate).isAfter(goal.getTargetDate())),
+    [plannerData.financialGoals, selectedDate],
+  );
 
   const datePickerRef = useRef<HTMLDivElement | null>(null);
   const isSmallScreen = useMediaQuery('(max-width:600px)');
   const areAllGoalsCompleted =
+    plannerData.financialGoals.length > 0 &&
     completedGoals.length === plannerData.financialGoals.length;
+
   return (
     <>
       <PageTour run={runTour} onDone={onTourDone} />
 
       <Grid container padding={2} spacing={2} height="100%">
+        {/* Header row */}
         <Grid
           size={12}
           display="flex"
@@ -171,7 +158,6 @@ const Planner = ({ plannerData, dispatch, headerRight, printRef: externalPrintRe
           alignItems="center"
           sx={{ flexWrap: { xs: 'wrap', sm: 'nowrap' }, gap: 1 }}
         >
-          {/* Left: title + date picker inline */}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap', minWidth: 0 }}>
             <Typography
               className="navbar-home"
@@ -195,20 +181,12 @@ const Planner = ({ plannerData, dispatch, headerRight, printRef: externalPrintRe
                     variant: 'standard',
                     size: 'small',
                     label: '',
-                    sx: {
-                      width: {
-                        xs: '120px',
-                        sm: '120px',
-                        md: 'auto',
-                      },
-                    },
+                    sx: { width: { xs: '120px', sm: '120px', md: 'auto' } },
                     InputProps: {
                       disableUnderline: true,
                       endAdornment: (
                         <InputAdornment position="end">
-                          <IconButton
-                            onClick={() => datePickerRef.current?.click()}
-                          >
+                          <IconButton onClick={() => datePickerRef.current?.click()}>
                             <CalendarIcon fontSize="small" />
                           </IconButton>
                         </InputAdornment>
@@ -220,23 +198,15 @@ const Planner = ({ plannerData, dispatch, headerRight, printRef: externalPrintRe
             </StyledBox>
           </Box>
 
-          {/* Right: save controls / action buttons */}
           {headerRight && (
-            <Box sx={{ display: 'flex', alignItems: 'center', flexShrink: 0, ml: 'auto' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexShrink: 0, ml: 'auto' }}>
               {headerRight}
             </Box>
           )}
         </Grid>
+
         {areAllGoalsCompleted ? (
-          <Box
-            sx={{
-              width: '100vw',
-              height: '100vh',
-              display: 'flex',
-              justifyContent: 'center',
-              mt: 5,
-            }}
-          >
+          <Box sx={{ width: '100vw', height: '100vh', display: 'flex', justifyContent: 'center', mt: 5 }}>
             <CongratulationsPage
               targetAmount={targetAmount}
               goals={plannerData.financialGoals.map((goal) => ({
@@ -246,69 +216,67 @@ const Planner = ({ plannerData, dispatch, headerRight, printRef: externalPrintRe
             />
           </Box>
         ) : (
-          <>
-            <Grid container size={12} spacing={2} sx={{ alignItems: 'stretch', mb: 4 }}>
-              <Grid
-                size={{ xs: 12, sm: 4, md: 4 }}
-                sx={{ display: 'flex' }}
-              >
-                <TargetBox
-                  targetAmount={targetAmount}
-                  dispatch={dispatch}
-                  setShowDrawer={setShowDrawerCallback}
-                  termTypeWiseProgressData={termTypeWiseProgressData}
-                />
-              </Grid>
-              <Grid size={{ xs: 12, sm: 8, md: 8 }} sx={{ display: 'flex', flexGrow: 1 }}>
-                <TermWiseProgressBox data={termTypeWiseProgressData} />
-              </Grid>
-            </Grid>
-            <Grid container size={12} spacing={2}>
-              <Grid size={{ xs: 12, sm: 12, md: 8, lg: 9 }}>
+          <Grid size={12}>
+            <PlannerStatStrip
+              targetAmount={targetAmount}
+              totalRequired={totalRequired}
+              totalInvesting={totalInvesting}
+              financialGoals={plannerData.financialGoals}
+              onGoalsClick={() => setShowGoalsDrawer(true)}
+              onAddGoal={() => setIsAddGoalOpen(true)}
+            />
+
+            <Tabs
+              value={activeTab}
+              onChange={(_, v) => setActiveTab(v as 0 | 1)}
+              sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
+            >
+              <Tab label="Investment Plan" />
+              <Tab label="Portfolio" />
+            </Tabs>
+
+            <Box role="tabpanel" hidden={activeTab !== 0}>
+              {activeTab === 0 && (
                 <InvestmentSuggestionsBox
                   dispatch={dispatch}
                   investmentAllocations={plannerData.investmentAllocations}
-                  investmentBreakdownBasedOnTermType={
-                    investmentBreakdownBasedOnTermType
-                  }
+                  investmentBreakdownBasedOnTermType={investmentBreakdownBasedOnTermType}
                   investmentLogs={plannerData.investmentLogs}
-                  goals={plannerData.financialGoals}
                 />
-              </Grid>
-              <Grid
-                size={{ xs: 12, sm: 12, md: 4, lg: 3 }}
-                sx={{
-                  display: { xs: 'none', sm: 'none', md: 'block', lg: 'block' },
-                }}
-              >
-                <GoalBox
-                  financialGoals={plannerData.financialGoals}
-                  investmentBreakdownForAllGoals={
-                    investmentBreakdownForAllGoals
-                  }
-                  selectedDate={selectedDate}
-                  dispatch={dispatch}
-                  useStyledBox={true}
-                />
-              </Grid>
-            </Grid>
-          </>
+              )}
+            </Box>
+
+            <Box role="tabpanel" hidden={activeTab !== 1}>
+              {activeTab === 1 && (
+                <StyledBox>
+                  <GoalGrowthChart
+                    sips={plannerData.investmentLogs}
+                    goals={plannerData.financialGoals}
+                    allSuggestions={aggregatedSuggestions}
+                    goalWiseSuggestions={goalWiseSuggestions}
+                  />
+                </StyledBox>
+              )}
+            </Box>
+          </Grid>
         )}
       </Grid>
 
+      {/* Goals drawer */}
       <Drawer
-        open={showDrawer}
-        onClose={() => setShowDrawerCallback(false)}
         anchor="right"
-        PaperProps={{ sx: { width: { xs: '85vw', sm: 360 }, maxWidth: 400 } }}
+        open={showGoalsDrawer}
+        onClose={() => setShowGoalsDrawer(false)}
+        sx={{ '& .MuiDrawer-paper': { width: { xs: '100%', sm: 560 }, p: 2, boxSizing: 'border-box' } }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 2, pt: 2, pb: 1 }}>
-          <Typography variant="subtitle1" fontWeight="bold">Goals</Typography>
-          <IconButton size="small" onClick={() => setShowDrawerCallback(false)}>
-            <CloseIcon fontSize="small" />
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+          <Typography variant="h6" fontWeight="bold">Financial Goals</Typography>
+          <IconButton size="small" onClick={() => setShowGoalsDrawer(false)}>
+            <span className="material-symbols-rounded" style={{ fontSize: '20px' }}>close</span>
           </IconButton>
         </Box>
-        <Box sx={{ px: 2, pb: 2, overflowY: 'auto' }}>
+
+        <Box sx={{ overflowY: 'auto', flex: 1 }}>
           <GoalBox
             financialGoals={plannerData.financialGoals}
             investmentBreakdownForAllGoals={investmentBreakdownForAllGoals}
@@ -319,12 +287,16 @@ const Planner = ({ plannerData, dispatch, headerRight, printRef: externalPrintRe
         </Box>
       </Drawer>
 
-      {/* Hidden print/export layout — always mounted, CSS-hidden from screen */}
+      <AddGoalPopup
+        isOpen={isAddGoalOpen}
+        onClose={() => setIsAddGoalOpen(false)}
+        dispatch={dispatch}
+      />
+
       <PrintableReport
         plannerData={plannerData}
         selectedDate={selectedDate}
         investmentBreakdownBasedOnTermType={investmentBreakdownBasedOnTermType}
-        termTypeWiseProgressData={termTypeWiseProgressData}
         printRef={printRef}
       />
     </>

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -171,6 +171,7 @@ export const formatIndianCurrency = (num: number): string => {
  * @param num - The number to format
  */
 export const formatCompactCurrency = (num: number): string => {
+  if (num < 0) return `-${formatCompactCurrency(-num)}`;
   const locale = getUserLocale();
   const localeCurrencyMap: { [key: string]: string } = {
     'en-IN': 'INR',


### PR DESCRIPTION
… plan (#016)

- Replace two-column sidebar layout with full-width tabbed view (Investment Plan / Portfolio)
- Add PlannerStatStrip with three stat tiles: Total Goal Target, Monthly Required, Monthly Investing
- Embed per-term goal chips (Short/Mid/Long) and "+ Add Goal" action inside the stat tile
- Move goals into a right-side drawer; remove standalone Goals button from header
- Remove semi-circle progress bar from GoalCard; show date range as caption instead
- Redesign investment breakdown chips with colored left-accent border and two-line label
- Compact CustomLegend: pie chart + term label side by side with horizontal legend rows
- Move term label and customize button into pie column, eliminating separate header row
- Add card border, background, and hover shadow to GoalCard
- Reduce PDF export size: switch from PNG/scale-2 to JPEG-0.88/scale-1.5, encode once
- Remove Term-wise Progress Summary from PrintableReport (always empty, redundant)
- 623 tests passing