### PR TITLE
Goal risk dashboard — per-goal on-track/at-risk chips (#018)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # goal-based-financial-planner Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-07-19
+Auto-generated from all feature plans. Last updated: 2026-08-22
 
 ## Active Technologies
 - TypeScript (React 18, CRA / react-scripts 5) + MUI v6 (`@mui/material` — Tabs, Tab already available), React 18 hooks (004-goals-tabbed-view)
@@ -27,6 +27,8 @@ Auto-generated from all feature plans. Last updated: 2026-07-19
 - Browser `localStorage` / Google Drive — no changes (016-layout-redesign)
 - TypeScript 4.x + React 19.2.4 + `@mui/material` v6, `@mui/x-charts` ^7.23.6 (already installed), `react-hook-form` (already present), `dayjs` ^1.11.13 (017-scenario-comparison)
 - Browser `localStorage`/File System Access API (local) + Google Drive REST API (cloud) via `src/util/storage/*Provider.ts` — new `scenarios` field on the existing `PlannerData` payload, no new storage mechanism (017-scenario-comparison)
+- TypeScript 4.x + React 19.2.4 + `@mui/material` v6 (`Chip`, already used by `GoalCard`/`PlannerStatStrip`), existing `src/domain/whatIf.ts` (`buildPortfolioWhatIfResult`, unmodified — reused, not extended), `dayjs` ^1.11.13 (indirectly, via `whatIf.ts`) (018-goal-risk-dashboard)
+- N/A — fully derived at render time from the existing `PlannerData` (`financialGoals`, `investmentAllocations`, `investmentLogs`) already loaded via `localStorage`/Google Drive; nothing new persisted, no `PlannerData` shape change (018-goal-risk-dashboard)
 
 - Markdown / N/A (documentation only) + N/A (static documentation files) (003-oss-documentation)
 
@@ -47,9 +49,9 @@ tests/
 Markdown / N/A (documentation only): Follow standard conventions
 
 ## Recent Changes
+- 018-goal-risk-dashboard: Added TypeScript 4.x + React 19.2.4 + `@mui/material` v6 (`Chip`, already used by `GoalCard`/`PlannerStatStrip`), existing `src/domain/whatIf.ts` (`buildPortfolioWhatIfResult`, unmodified — reused, not extended), `dayjs` ^1.11.13 (indirectly, via `whatIf.ts`)
 - 017-scenario-comparison: Added TypeScript 4.x + React 19.2.4 + `@mui/material` v6, `@mui/x-charts` ^7.23.6 (already installed), `react-hook-form` (already present), `dayjs` ^1.11.13
 - 016-layout-redesign: Added TypeScript 4.x + React 19.2.4 + MUI v6 (`@mui/material`, `@mui/x-charts`), `dayjs`, Vite 8.0.0
-- 014-portfolio-growth-chart: Added TypeScript 4.x + React 19.2.4 + `@mui/material` v6, `@mui/x-charts` ^7.23.6 (already installed), `dayjs` ^1.11.13
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/018-goal-risk-dashboard/checklists/requirements.md
+++ b/specs/018-goal-risk-dashboard/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Goal Risk Dashboard
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. The recurring-goal clarification was resolved (Option A: recurring goals show
+  a "not evaluated" treatment rather than on-track/at-risk) and is now reflected in FR-008,
+  FR-005, the Key Entities, and the edge cases. Ready for `/speckit.clarify` (optional) or
+  `/speckit.plan`.

--- a/specs/018-goal-risk-dashboard/data-model.md
+++ b/specs/018-goal-risk-dashboard/data-model.md
@@ -1,0 +1,86 @@
+# Data Model: Goal Risk Dashboard
+
+All entities below are **derived at render time** and **not persisted** — no changes to
+`PlannerData`, `localStorage`, or the Google Drive schema. Everything is a pure function of data
+that already exists: `financialGoals`, `investmentAllocations`, and `investmentLogs` on the current
+`PlannerData`.
+
+## GoalRiskDisplayStatus
+
+A per-goal, non-persisted classification shown directly on the UI.
+
+```ts
+export type GoalRiskDisplayStatus = 'on-track' | 'at-risk' | 'not-evaluated';
+```
+
+| Value | Meaning | Applies to |
+|---|---|---|
+| `on-track` | The shared invested corpus is projected to fully cover this goal's withdrawal at its target date, under the plan's current (unmodified) assumptions. | One-time goals only |
+| `at-risk` | The shared invested corpus is projected to be insufficient at this goal's target date. | One-time goals only |
+| `not-evaluated` | No shortfall projection exists for this goal type today (FR-008). Never implies either of the above. | Recurring goals only |
+
+**Derivation** (`src/domain/goalRiskStatus.ts`, new file):
+
+```ts
+export function deriveGoalRiskStatuses(
+  goals: FinancialGoal[],
+  baseline: PortfolioWhatIfResult, // built with EMPTY adjustments — see research.md
+): Record<string /* goal.id */, GoalRiskDisplayStatus>
+```
+
+- For each goal with `goalType !== GoalType.ONE_TIME` → `'not-evaluated'`.
+- For each one-time goal, look up its `WhatIfGoalMarker` in `baseline.markers` by `goalId`:
+  - `marker.portfolioValueAfter < 0` → `'at-risk'`
+  - otherwise → `'on-track'`
+- A one-time goal will always have exactly one corresponding marker whenever `baseline` was built
+  from a goal list that included it (see `buildPortfolioWhatIfResult` in `whatIf.ts`), so no
+  fallback/undefined case needs to be designed for in practice — the function is still total or
+  falls back to `'on-track'` defensively if a lookup ever misses, without throwing.
+
+## GoalRiskSummary
+
+A portfolio-level aggregate for the always-visible stat strip (User Story 2 / FR-005).
+
+```ts
+export type GoalRiskSummary = {
+  atRisk: number;
+  total: number; // one-time goals only; recurring goals never counted (FR-005)
+};
+```
+
+**Derivation** (`src/domain/goalRiskStatus.ts`, new file):
+
+```ts
+export function summarizeGoalRisk(
+  statuses: Record<string, GoalRiskDisplayStatus>,
+): GoalRiskSummary
+```
+
+- Filters out every `'not-evaluated'` entry, then counts `'at-risk'` vs. the remaining total.
+- `total === 0` (no one-time goals in the plan, or no goals at all) is the caller's signal to
+  suppress the summary/caption entirely (FR-006, and the edge case for all-recurring plans).
+
+## Relationship to existing types
+
+```text
+FinancialGoal[]  ──┐
+investmentAllocations ─┼─▶ buildPortfolioWhatIfResult(goals, sips, allocations, EMPTY_ADJUSTMENTS)
+investmentLogs (sips) ─┘        │  (whatIf.ts — UNCHANGED)
+                                 ▼
+                        PortfolioWhatIfResult
+                         { markers: WhatIfGoalMarker[], totalShortfall, status, ... }
+                                 │
+                                 ▼
+                  deriveGoalRiskStatuses(goals, baseline)   ──▶  Record<goalId, GoalRiskDisplayStatus>
+                                 │                                        │
+                                 ▼                                        ▼
+                  summarizeGoalRisk(statuses)                    GoalCard chip (per goal,
+                    ──▶ GoalRiskSummary                            inside Goals drawer)
+                                 │
+                                 ▼
+                  PlannerStatStrip summary + reconciled
+                  "Monthly Investing" caption/color (FR-009)
+```
+
+No new entity is stored in `PlannerData`. No new IndexedDB/localStorage/Drive fields. No schema
+migration.

--- a/specs/018-goal-risk-dashboard/plan.md
+++ b/specs/018-goal-risk-dashboard/plan.md
@@ -1,0 +1,88 @@
+# Implementation Plan: Goal Risk Dashboard
+
+**Branch**: `018-goal-risk-dashboard` | **Date**: 2026-08-22 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/018-goal-risk-dashboard/spec.md`
+
+## Summary
+
+Surface the goal-attainment signal that today only exists inside the What-If tab (`whatIf.ts`'s
+`buildPortfolioWhatIfResult`, called with no adjustments) as an always-visible, non-interactive
+on-track/at-risk indicator on the main Planner screen: a per-goal chip on each one-time `GoalCard`
+(recurring goals get a distinct "not evaluated" chip instead), a portfolio-level "N of M goals at
+risk" summary, and a reconciled `PlannerStatStrip` shortfall caption that replaces its current naive
+`totalInvesting >= totalRequired` heuristic. No new simulation logic — a new, small pure derivation
+module reads the same per-goal `portfolioValueAfter` data the What-If tab's markers already carry,
+guaranteeing the two surfaces can never disagree for an unmodified plan.
+
+## Technical Context
+
+**Language/Version**: TypeScript 4.x + React 19.2.4
+**Primary Dependencies**: `@mui/material` v6 (`Chip`, already used by `GoalCard`/`PlannerStatStrip`), existing `src/domain/whatIf.ts` (`buildPortfolioWhatIfResult`, unmodified — reused, not extended), `dayjs` ^1.11.13 (indirectly, via `whatIf.ts`)
+**Storage**: N/A — fully derived at render time from the existing `PlannerData` (`financialGoals`, `investmentAllocations`, `investmentLogs`) already loaded via `localStorage`/Google Drive; nothing new persisted, no `PlannerData` shape change
+**Testing**: Vitest + `@testing-library/react` ^16.0.1, matching existing conventions (`whatIf.test.ts`, `GoalCard/index.test.tsx`)
+**Target Platform**: Browser (modern Chrome, Firefox, Safari); responsive from 375px to 1920px (unchanged from 016-layout-redesign)
+**Project Type**: React SPA (single-page web app) — no backend
+**Performance Goals**: Negligible — one extra `useMemo`'d pass over data already computed for the What-If tab (typically 3–10 goals); no perceptible render-time change
+**Constraints**: No new npm dependencies; MUST NOT modify `whatIf.ts`'s public behavior (only read its existing output); the new per-goal/summary indicators MUST be static (no click/navigation), per the resolved clarification
+**Scale/Scope**: Same as existing plan — a handful to a few dozen goals per plan, client-side only
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Clear Layering | ✅ Pass | All new logic lives in `src/domain/goalRiskStatus.ts` (pure functions, no UI). `GoalCard`/`PlannerStatStrip` stay presentational — they receive already-derived `GoalRiskDisplayStatus`/`GoalRiskSummary` values as props, no calculation inside components. `whatIf.ts` itself is untouched. |
+| II. Feature Co-location + Stable Shared Surface | ✅ Pass | New domain concept in `src/domain/` (shared, no UI dependency). Derivation is computed once in `Planner/index.tsx` (page-specific, matching that file's existing `useMemo` style for `totalRequired`/`totalInvesting`) and passed down — no new cross-page shared hook manufactured for a single call site. |
+| III. Upgrade-Friendly Boundaries | ✅ Pass | No new 3rd-party dependency; reuses the already-wrapped MUI `Chip` pattern already present in `GoalCard` and `PlannerStatStrip`. |
+| IV. Type Safety | ✅ Pass | New `GoalRiskDisplayStatus` (`'on-track' \| 'at-risk' \| 'not-evaluated'`) and `GoalRiskSummary` types defined once in `src/domain/goalRiskStatus.ts` and imported everywhere they're used; no `any`. |
+| V. Predictable Change | ✅ Pass | `deriveGoalRiskStatuses`/`summarizeGoalRisk` are financial-adjacent derivation logic and get unit tests (one-time at-risk/on-track from markers, recurring → not-evaluated, shared-shortfall-marks-both-goals, empty-goals/all-recurring → total 0). `PlannerStatStrip`'s reconciled caption gets a new component test (none existed before); `GoalCard`'s existing test file is extended for the new chip. |
+
+**No violations. No Complexity Tracking table needed.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/018-goal-risk-dashboard/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── quickstart.md        ← Phase 1 output
+├── checklists/
+│   └── requirements.md
+└── tasks.md              ← Phase 2 output (/speckit.tasks — not created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── domain/
+│   ├── goalRiskStatus.ts                  ← NEW: deriveGoalRiskStatuses, summarizeGoalRisk, GoalRiskDisplayStatus, GoalRiskSummary
+│   ├── goalRiskStatus.test.ts             ← NEW
+│   └── whatIf.ts                          ← UNCHANGED (reused: buildPortfolioWhatIfResult, WhatIfGoalMarker.portfolioValueAfter)
+│
+└── pages/
+    └── Planner/
+        ├── index.tsx                              ← MODIFIED: computes baseline (EMPTY_ADJUSTMENTS) + goalRiskStatus.ts derivations via useMemo, passes down to PlannerStatStrip and (via GoalBox) GoalList/GoalCard
+        └── components/
+            ├── PlannerStatStrip/
+            │   ├── index.tsx                       ← MODIFIED: accepts risk summary/status props, replaces totalInvesting>=totalRequired heuristic (FR-009)
+            │   └── index.test.tsx                  ← NEW
+            ├── GoalBox/
+            │   └── goalList.tsx                    ← MODIFIED: threads per-goal status prop through to GoalCard
+            └── GoalCard/
+                ├── index.tsx                       ← MODIFIED: renders on-track/at-risk/not-evaluated chip
+                └── index.test.tsx                  ← MODIFIED: covers new chip's three states
+```
+
+**Structure Decision**: Single existing frontend project (no backend, no new top-level directory).
+This feature adds one new domain module (`src/domain/goalRiskStatus.ts`) that reuses `whatIf.ts`
+without modifying it, and modifies three existing presentational components to render the derived
+data as props — consistent with the codebase's existing domain/page/component layering.
+
+## Complexity Tracking
+
+*No entries — Constitution Check has no violations.*

--- a/specs/018-goal-risk-dashboard/quickstart.md
+++ b/specs/018-goal-risk-dashboard/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart: Verifying the Goal Risk Dashboard
+
+Manual verification steps once the feature is implemented (`npm start`, then in the browser).
+
+1. **Set up a mixed plan**: Create a plan with:
+   - One one-time goal funded well ahead of its target date (log enough SIPs against it that it's
+     clearly on track).
+   - One one-time goal with little/no SIP funding relative to its target amount (clearly at risk).
+   - One recurring goal.
+2. **Stat strip, no clicks**: On the Planner page (no tab navigation, no drawer opened), verify the
+   "Monthly Investing" stat tile's caption/color reflects the *at-risk* case (not the old
+   `totalInvesting >= totalRequired` heuristic) whenever the shared corpus is projected short at any
+   goal's target date — including cases where the naive total-vs-total comparison would have looked
+   fine. Verify a summary figure is visible reading something like "1 of 2 goals at risk" (only the
+   two one-time goals counted; the recurring goal is not part of the denominator).
+3. **Open the Goals drawer**: Click through to the per-goal list. Verify:
+   - The on-track one-time goal shows an "on-track" chip.
+   - The at-risk one-time goal shows an "at-risk" chip, visually distinct (color + icon/label, not
+     color alone).
+   - The recurring goal shows a "not evaluated" treatment, visually distinct from both of the above
+     (never reads as either on-track or at-risk).
+   - No chip is clickable / navigates anywhere (static display only, per FR-007).
+4. **Live update — funding an at-risk goal**: With the drawer still open (or after reopening it),
+   log an additional SIP against the at-risk goal large enough to close its projected shortfall.
+   Verify its chip flips to "on-track" without a page reload, and the stat-strip summary count
+   decreases accordingly.
+5. **Live update — degrading an on-track goal**: Lower the expected return rate on an investment
+   type funding the on-track goal until its projection can no longer cover its target. Verify its
+   chip flips to "at-risk" without a page reload.
+6. **No goals**: Start a fresh plan with zero goals. Verify neither the stat-strip summary/caption
+   nor any per-goal indicator is shown (nothing to evaluate).
+7. **All-recurring plan**: Create a plan with only recurring goals (no one-time goals). Verify every
+   goal shows "not evaluated" and the stat-strip summary does not display a misleading "0 of 0 at
+   risk" — it should read as "nothing evaluated" or be suppressed, matching the no-goals case.
+8. **Consistency with What If**: With the same plan (no sliders touched), open the What If tab.
+   Verify its baseline reading (shortfall amount / on-track status) agrees with what the dashboard
+   showed in steps 2–3 — the two must never disagree for the unmodified plan (SC-002).
+9. **Two goals sharing a shortfall**: Set up two one-time goals due in the same month whose combined
+   withdrawal exceeds the shared corpus at that point (but either alone would be covered). Verify
+   *both* goals show "at-risk" — matching the existing What If tab's reporting for the same
+   situation.

--- a/specs/018-goal-risk-dashboard/research.md
+++ b/specs/018-goal-risk-dashboard/research.md
@@ -1,0 +1,88 @@
+# Research: Goal Risk Dashboard
+
+## Decision: Read status from `whatIf.ts`'s existing output — no new simulation
+
+**Decision**: Do not touch `src/domain/whatIf.ts`. Add one new, small pure module,
+`src/domain/goalRiskStatus.ts`, that derives a per-goal display status and a portfolio summary
+purely from data `buildPortfolioWhatIfResult` already returns when called with empty adjustments
+(`{ goalInflationRates: {}, investmentReturnRates: {} }`) — the exact same "baseline" the What-If
+tab already computes via `useWhatIf`.
+
+**Rationale**:
+- `WhatIfGoalMarker.portfolioValueAfter` is already documented as "negative means this goal (or an
+  earlier one sharing its month) couldn't be fully funded" — i.e. it is already the per-goal
+  attainment signal this feature needs. No new math, no risk of the new indicator disagreeing with
+  what the What-If tab reports for the unmodified plan (this is exactly Success Criterion SC-002).
+- The portfolio-wide dip that produces `PortfolioWhatIfResult.totalShortfall` can only occur in a
+  month where a withdrawal happens (compounding alone never produces a dip), so the overall
+  `status`/`totalShortfall` is mathematically equivalent to "at least one marker's
+  `portfolioValueAfter < 0`". This means the reconciled stat-strip signal (FR-009) and the per-goal
+  chips (FR-001) are guaranteed consistent by construction — nothing to keep in sync by hand.
+- Reusing rather than modifying `whatIf.ts` respects Constitution Principle I (no duplicated
+  calculations) and keeps this feature's diff small and reversible (Principle V).
+
+**Alternatives considered**:
+- *Extend `buildPortfolioWhatIfResult` to also return a `Record<goalId, GoalAttainmentStatus>`
+  directly* — rejected: would touch a well-tested, already-shipped engine (017) for a derivation
+  that's entirely expressible from its existing output; higher blast radius for no gain.
+- *Run an independent, simplified per-goal solvency check (e.g. compare each goal's own SIPs against
+  its own target, ignoring shared-corpus sequencing)* — rejected: this is exactly the naive
+  heuristic `PlannerStatStrip` uses today (`totalInvesting >= totalRequired`), which the
+  clarification session already identified as misleading (ignores timing) and asked to retire, not
+  reintroduce at goal level.
+
+## Decision: Compute once per render at the Planner page level, not inside a shared hook
+
+**Decision**: `Planner/index.tsx` computes the baseline result and the derived per-goal statuses via
+plain `useMemo`s (matching its existing style — `targetAmount`, `totalRequired`, `totalInvesting`
+are already computed this way in that file), then passes the results down as props to
+`PlannerStatStrip` and, through `GoalBox` → `GoalList`, to `GoalCard`. The `What If` tab keeps using
+its own `useWhatIf` hook unchanged (it independently computes the same baseline internally, plus
+the adjusted/top-up results the dashboard doesn't need).
+
+**Rationale**: `buildPortfolioWhatIfResult` is a pure, `useMemo`-cheap function over data already in
+memory (typically 3–10 goals) — recomputing it once for the main page and once inside the What-If
+tab is a negligible duplicate calculation, not a duplicated *business rule* (the rule itself still
+lives in exactly one place, `whatIf.ts`). Introducing a shared hook or lifting state to avoid this
+would add prop-plumbing between two otherwise-independent tabs for no measurable benefit.
+
+**Alternatives considered**:
+- *Extract a `useGoalRiskStatus` hook* — considered, but with only one call site (`Planner/index.tsx`)
+  today, a hook adds indirection without reuse; a plain `useMemo` next to the file's existing
+  derivations is more consistent with the surrounding code (Principle II: keep page-specific
+  derivation co-located, don't manufacture shared surface prematurely).
+
+## Decision: Where per-goal chips render — inside the existing Goals drawer, not a new surface
+
+**Decision**: The per-goal indicator (FR-001) renders on `GoalCard`, which already only renders
+inside the Goals drawer (opened via the "Goals" stat tile's chips / the drawer trigger), not
+directly on the always-visible page body. The always-visible surface (no click required) is the
+`PlannerStatStrip` summary from User Story 2 (FR-005) and the reconciled shortfall caption (FR-009).
+
+**Rationale**: This matches the codebase as it stands — `GoalCard` has never rendered outside that
+drawer, and the spec's "without requiring the user to open the What-If tab or touch any sliders"
+is satisfied by not needing the What-If tab; opening the pre-existing Goals drawer (a single click,
+not a slider) is the established way to browse individual goals in this app and isn't in tension
+with any spec requirement or success criterion.
+
+**Alternatives considered**:
+- *Add goal chips to a new, always-visible list on the main page body* — rejected as unnecessary
+  scope: no clarification or requirement asked for individual goals to be visible without any
+  interaction, only that the *fact* of risk be surface-level (satisfied by the summary count) and
+  that per-goal detail not require the What-If tab specifically.
+
+## Decision: "Not evaluated" is a third display state, not an absence of markup
+
+**Decision**: Introduce `GoalRiskDisplayStatus = 'on-track' | 'at-risk' | 'not-evaluated'` in the new
+domain module, rather than reusing `whatIf.ts`'s `GoalAttainmentStatus` (`'on-track' | 'at-risk'`)
+directly with `undefined` standing in for "not evaluated".
+
+**Rationale**: Per the resolved clarification (FR-008), recurring goals must show a *visually
+distinct* treatment, not simply omit a chip — an explicit third value makes that a compile-time
+requirement on every render path (`GoalCard` must handle all three), rather than a convention that
+"no chip" means "recurring", which is easy to accidentally collapse with a loading/empty state.
+
+**Alternatives considered**:
+- *Reuse `GoalAttainmentStatus` and treat `undefined`/missing map entry as "not evaluated"* —
+  rejected: makes "not evaluated" an implicit, easy-to-miss case rather than an explicit one; harder
+  to unit test exhaustively.

--- a/specs/018-goal-risk-dashboard/spec.md
+++ b/specs/018-goal-risk-dashboard/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: Goal Risk Dashboard
+
+**Feature Branch**: `018-goal-risk-dashboard`
+**Created**: 2026-08-22
+**Status**: Draft
+**Input**: User description: "Goal risk dashboard: surface at-risk vs on-track status per goal on the main Planner screen using the current (non-What-If) assumptions. Reuse the existing goal attainment logic from src/domain/whatIf.ts (GoalAttainmentStatus, on-track/at-risk determination) so the same rules that power the What-If tab's live projection also drive a persistent, always-visible status indicator — without requiring the user to open the What-If tab or touch any sliders. This should read as a natural extension of the 016-layout-redesign stat strip / goal chips, showing which goals are on track and which are at risk under the plan's actual current assumptions (inflation rate, investment allocations, SIP amounts) as already stored in PlannerData."
+
+## Clarifications
+
+### Session 2026-08-22
+
+- Q: The existing `PlannerStatStrip` already shows a portfolio-level on-track/shortfall caption today, computed with a simple total-invested-vs-total-required comparison that ignores timing — separate from the corpus-sequencing engine this feature reuses. Should the two signals be reconciled? → A: Yes — replace the stat strip's existing heuristic so it sources from the same per-goal risk computation this feature introduces, so the two signals on the screen always agree.
+- Q: In a mixed plan (one-time + recurring goals), the summary counts only one-time goals and stays silent about the excluded recurring goals — or should it explicitly call out the exclusion in the same line? → A: Stay silent — the summary reads "N of M goals at risk" for one-time goals only; a recurring goal's own "not evaluated" chip is the only place its status is shown.
+- Q: Should the per-goal risk indicator support any click/navigation interaction (e.g., deep-link into What-If, show a shortfall breakdown)? → A: No — it is a static, non-interactive badge for this feature; drill-down is a possible later enhancement, not in scope now.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - See which goals are at risk without leaving the main screen (Priority: P1)
+
+A user who has set up goals, investment allocations, and logged some SIP contributions opens the Planner page (not the What-If tab) and immediately sees, for each goal, whether it is on track to be fully funded by its target date or at risk of falling short — based on the plan exactly as it stands today, with no sliders touched.
+
+**Why this priority**: This is the entire point of the feature — turning a signal that currently only exists inside an exploratory tool (What-If) into an always-visible fact about the real plan. Without this, the feature doesn't exist.
+
+**Independent Test**: Can be fully tested by loading a plan containing at least one underfunded goal and one adequately funded goal, opening the Planner page only, and confirming each goal shows the correct status without visiting the What-If tab.
+
+**Acceptance Scenarios**:
+
+1. **Given** a plan with a one-time goal whose logged SIPs are projected to fully cover its target amount by its target date, **When** the user views the Planner page, **Then** that goal displays an "on-track" status indicator.
+2. **Given** a plan with a one-time goal whose shared invested corpus is projected to run short at the goal's target date, **When** the user views the Planner page, **Then** that goal displays an "at-risk" status indicator.
+3. **Given** a plan with no goals at all, **When** the user views the Planner page, **Then** no risk status indicators are shown.
+
+---
+
+### User Story 2 - See at a glance how many goals need attention (Priority: P2)
+
+A user with several goals wants a single summary figure — how many goals are at risk right now — without having to scan every individual goal chip and count for themselves.
+
+**Why this priority**: Individual per-goal indicators (P1) already deliver the core value; a summary count is a fast-scan convenience on top of that, valuable but not blocking.
+
+**Independent Test**: Can be tested by loading a plan with a known mix of at-risk and on-track goals and confirming a summary count (e.g., "2 of 5 goals at risk") appears on the main screen and matches the individual indicators.
+
+**Acceptance Scenarios**:
+
+1. **Given** a plan with 5 goals where 2 are at risk, **When** the user views the Planner page, **Then** a summary shows 2 goals at risk out of 5.
+2. **Given** a plan where every goal is on track, **When** the user views the Planner page, **Then** the summary reflects zero goals at risk (and does not read as an alarming/negative state).
+
+---
+
+### User Story 3 - Status stays current as the plan changes (Priority: P3)
+
+A user edits a goal's target amount, adjusts an investment allocation, or logs a new SIP contribution, and wants the risk status to reflect that change immediately, without saving, reloading, or switching tabs.
+
+**Why this priority**: Correctness over time matters, but the initial static read (P1) already delivers the core value the first time the page loads; this story hardens that value against staleness.
+
+**Independent Test**: Can be tested by loading a plan with an at-risk goal, increasing its SIP contribution enough to close the shortfall, and confirming the indicator flips to on-track on the same screen without a manual refresh.
+
+**Acceptance Scenarios**:
+
+1. **Given** a goal currently shown as at-risk, **When** the user increases the monthly SIP amount funding it enough to close the projected shortfall, **Then** the goal's status updates to on-track without a page reload.
+2. **Given** a goal currently shown as on-track, **When** the user reduces its investment allocation return rate enough to create a shortfall, **Then** the goal's status updates to at-risk without a page reload.
+
+---
+
+### Edge Cases
+
+- What happens when a plan has goals but none has any logged SIP contributions yet? Each such goal is evaluated the same way (its funding requirement vs. its projected $0 corpus) and is shown as at-risk if the target amount is greater than $0.
+- What happens when two goals share a target date (or month) and the shared corpus can only cover one of them? Both goals show at-risk, since the underlying corpus is insufficient at that point for the combined withdrawal — matching what the What-If tab already reports for the same situation.
+- How does the system handle a goal added moments ago with no time to accumulate contributions before its own target date? It is shown as at-risk, reflecting the real shortfall, not treated as a special/exempt case.
+- What happens while plan data is still loading (e.g., right after opening the app)? No status indicator is shown until the plan's goals, allocations, and SIP data have finished loading.
+- What happens when a plan contains only recurring goals and no one-time goals? Every goal shows the "not evaluated" treatment, and the portfolio-level summary reflects zero one-time goals evaluated rather than showing a misleading 0-at-risk count.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST display an on-track/at-risk status indicator for every one-time goal directly on the main Planner screen, visible without navigating to the What-If tab or adjusting any control.
+- **FR-002**: The status shown MUST be computed from the plan's currently stored assumptions only — each goal's own inflation rate (or the plan's default), each investment type's own expected return rate, and the SIP contributions actually logged — with no user-adjusted overrides applied.
+- **FR-003**: A goal MUST be marked at-risk when the shared invested corpus is projected to be insufficient to cover that goal's full withdrawal at its target date under those current assumptions; otherwise it MUST be marked on-track.
+- **FR-004**: The status indicator MUST recompute automatically whenever the underlying plan data changes (goals added/edited/removed, investment allocations changed, or SIP entries logged/edited/removed) — reflected on the same screen without requiring a manual refresh or reload.
+- **FR-005**: System MUST display a portfolio-level summary showing how many one-time goals are at risk out of the total number of one-time goals evaluated. Recurring goals are excluded from both the numerator and denominator of this count, consistent with FR-008, and the summary text does not call out that exclusion — a recurring goal's "not evaluated" state is visible only on its own indicator.
+- **FR-006**: When a plan contains no goals, the system MUST NOT display any risk status indicator or summary.
+- **FR-007**: The visual treatment distinguishing at-risk from on-track MUST be clearly distinguishable at a glance (e.g., distinct color and icon/label), consistent with the status conventions already used elsewhere on the Planner screen's stat strip and goal chips. The indicator is a static display element only — it MUST NOT carry a click/navigation action (e.g., no deep-link into the What-If tab or drill-down breakdown) as part of this feature.
+- **FR-008**: Recurring goals MUST NOT display an on-track/at-risk status, since no shortfall projection exists for them today; they MUST instead be shown with a visually distinct "not evaluated" treatment so their absence of a verified status is never mistaken for either an on-track or at-risk determination.
+- **FR-009**: The existing portfolio-level on-track/shortfall indicator on the main Planner screen (today a simple total-invested-vs-total-required comparison) MUST be updated to source from the same per-goal risk computation this feature introduces, so it and the new per-goal indicators never disagree about the same plan.
+
+### Key Entities *(include if feature involves data)*
+
+- **Goal Risk Status**: A derived, non-persisted attribute of a one-time goal — either "on-track" or "at-risk" — computed at render time from the goal's target amount/date, its inflation rate, the relevant investment allocations' expected return rates, and logged SIP contributions. Not stored in `PlannerData`; recalculated whenever any of its inputs change. Recurring goals do not get this attribute; they are always shown as "not evaluated" (see FR-008).
+- **Portfolio Risk Summary**: A derived count of how many one-time goals are at-risk versus the total number of one-time goals, shown alongside the individual indicators.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can determine whether any of their goals are at risk within 5 seconds of loading the Planner page, without opening any other tab or touching any control.
+- **SC-002**: Every one-time goal's displayed status matches the outcome the What-If tab would show for that goal under unmodified (zero-override) assumptions, 100% of the time.
+- **SC-003**: After editing a goal, an investment allocation, or a SIP entry, the displayed status for affected goals reflects the change immediately, with no separate save, refresh, or navigation step.
+- **SC-004**: A user can state the total number of at-risk goals in their plan by reading a single summary figure, without individually counting status indicators themselves.

--- a/specs/018-goal-risk-dashboard/tasks.md
+++ b/specs/018-goal-risk-dashboard/tasks.md
@@ -1,0 +1,168 @@
+# Tasks: Goal Risk Dashboard
+
+**Input**: Design documents from `/specs/018-goal-risk-dashboard/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, quickstart.md ✅
+
+**Tests**: Included. Constitution Principle V mandates unit tests for financial calculation logic (the new `goalRiskStatus.ts` derivation), and Principle V's existing precedent in this codebase (e.g. `whatIf.test.ts`, `GoalCard/index.test.tsx`) extends that to component-level coverage for the new chip/caption behavior.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no shared dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Exact file paths are included in every task description
+
+---
+
+## Phase 1: Setup (File Scaffolding)
+
+**Purpose**: Create the new domain module so Foundational work has a file to fill in.
+
+- [x] T001 Create `src/domain/goalRiskStatus.ts` with exported type stubs `GoalRiskDisplayStatus` (`'on-track' | 'at-risk' | 'not-evaluated'`) and `GoalRiskSummary` (`{ atRisk: number; total: number }`), plus empty-bodied exported function signatures `deriveGoalRiskStatuses(goals: FinancialGoal[], baseline: PortfolioWhatIfResult): Record<string, GoalRiskDisplayStatus>` and `summarizeGoalRisk(statuses: Record<string, GoalRiskDisplayStatus>): GoalRiskSummary`
+- [x] T002 [P] Create `src/domain/goalRiskStatus.test.ts` with imports of the two functions/types above and an empty `describe('goalRiskStatus', ...)` block
+
+**Checkpoint**: New files exist and import cleanly — `npm run build` passes
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The reusable derivation and its wiring into the Planner page that every user story depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T003 [P] Export a shared `EMPTY_ADJUSTMENTS: Adjustments` constant (`{ goalInflationRates: {}, investmentReturnRates: {} }`) from `src/domain/whatIf.ts`; update `src/pages/Planner/hooks/useWhatIf.ts` to import it instead of its local `const EMPTY_ADJUSTMENTS` declaration (no behavior change — same object shape, now defined once)
+- [x] T004 Implement `deriveGoalRiskStatuses(goals, baseline)` in `src/domain/goalRiskStatus.ts`: for each goal with `goalType !== GoalType.ONE_TIME` → `'not-evaluated'`; for each one-time goal, find its `WhatIfGoalMarker` in `baseline.markers` by `goalId` and map `portfolioValueAfter < 0` → `'at-risk'`, otherwise → `'on-track'` (default to `'on-track'` defensively if no marker is found, per data-model.md)
+- [x] T005 Implement `summarizeGoalRisk(statuses)` in `src/domain/goalRiskStatus.ts`: filter out `'not-evaluated'` entries, return `{ atRisk: <count of 'at-risk'>, total: <remaining count> }`
+- [x] T006 [P] Write unit tests in `src/domain/goalRiskStatus.test.ts` covering: (1) one-time goal with a positive `portfolioValueAfter` marker → `'on-track'`, (2) one-time goal with a negative `portfolioValueAfter` marker → `'at-risk'`, (3) recurring goal → always `'not-evaluated'` regardless of markers, (4) two one-time goals sharing a negative marker at the same withdrawal month → both `'at-risk'`, (5) empty goals array → empty statuses map and `summarizeGoalRisk` returns `{ atRisk: 0, total: 0 }`, (6) all-recurring plan (no one-time goals) → `summarizeGoalRisk` returns `{ atRisk: 0, total: 0 }` even though goals exist
+- [x] T007 In `src/pages/Planner/index.tsx`, add three `useMemo` derivations alongside the existing `totalRequired`/`totalInvesting` ones: `baseline` (`buildPortfolioWhatIfResult(plannerData.financialGoals, plannerData.investmentLogs, plannerData.investmentAllocations, EMPTY_ADJUSTMENTS)`, deps on those three `plannerData` fields), `goalRiskStatuses` (`deriveGoalRiskStatuses(plannerData.financialGoals, baseline)`, deps on `plannerData.financialGoals` + `baseline`), and `goalRiskSummary` (`summarizeGoalRisk(goalRiskStatuses)`, deps on `goalRiskStatuses`)
+
+**Checkpoint**: `npm run build` and `npm run test:ci` pass; no visible UI change yet (values computed but not yet consumed)
+
+---
+
+## Phase 3: User Story 1 - See which goals are at risk without leaving the main screen (Priority: P1) 🎯 MVP
+
+**Goal**: Every one-time goal shows an on-track/at-risk chip (recurring goals show "not evaluated") wherever goals are browsed today — the Goals drawer — without needing the What-If tab.
+
+**Independent Test**: Load a plan with one underfunded and one adequately funded one-time goal, open the Goals drawer (no What-If tab, no sliders), and confirm each goal's chip matches its actual funding state.
+
+- [x] T008 [US1] Add a `riskStatus: GoalRiskDisplayStatus` prop to `GoalCard` in `src/pages/Planner/components/GoalCard/index.tsx`; render a static (non-interactive, no `onClick`) `Chip` near the goal name using the existing `material-symbols-rounded` icon convention already used elsewhere in this file — distinct color + icon + text label per state (e.g. success/"check_circle"/"On track", warning/"warning"/"At risk", neutral/"help"/"Not evaluated") so color is never the only signal (FR-007)
+- [x] T009 [P] [US1] Extend `src/pages/Planner/components/GoalCard/index.test.tsx` with cases asserting each of the three `riskStatus` values renders its corresponding label and that the chip has no click handler attached
+- [x] T010 [US1] Add a `goalRiskStatuses: Record<string, GoalRiskDisplayStatus>` prop to `GoalListProps` in `src/pages/Planner/components/GoalBox/goalList.tsx`; for each rendered goal, look up `goalRiskStatuses[goal.id]` and pass it as `riskStatus` to `<GoalCard>`
+- [x] T011 [P] [US1] Create `src/pages/Planner/components/GoalBox/goalList.test.tsx` (new file, mocking `GoalCard`) asserting that each goal receives the `riskStatus` looked up from the `goalRiskStatuses` map by its `id`
+- [x] T012 [US1] Add a `goalRiskStatuses: Record<string, GoalRiskDisplayStatus>` prop to `GoalBoxProps` in `src/pages/Planner/components/GoalBox/index.tsx`; forward it, unchanged, to all three `<GoalList>` call sites (pending, completed, recurring)
+- [x] T013 [US1] Pass `goalRiskStatuses={goalRiskStatuses}` from `src/pages/Planner/index.tsx` into its `<GoalBox>` usage (the Goals drawer)
+- [x] T014 [P] [US1] Update `src/pages/Planner/components/GoalBox/index.test.tsx`'s `MockGoalList` to capture and expose the `goalRiskStatuses` prop it receives, and add a test asserting `GoalBox` forwards the prop it's given down to `GoalList` unchanged
+
+**Checkpoint**: Opening the Goals drawer shows the correct chip for every goal, including "not evaluated" recurring goals; `npm run test:ci` passes
+
+---
+
+## Phase 4: User Story 2 - See at a glance how many goals need attention (Priority: P2)
+
+**Goal**: The always-visible stat strip shows a one-time-goal risk count ("N of M goals at risk") and its existing shortfall caption/color is reconciled to source from the same computation (FR-005, FR-009) instead of the old `totalInvesting >= totalRequired` heuristic.
+
+**Independent Test**: Load a plan with a known mix of at-risk/on-track one-time goals (and at least one recurring goal), view the Planner page without opening any drawer or tab, and confirm the stat strip's count and caption/color match the per-goal chips from US1 and exclude the recurring goal from the count.
+
+- [x] T015 [US2] Add a `goalRiskSummary: GoalRiskSummary` prop to `PlannerStatStripProps` in `src/pages/Planner/components/PlannerStatStrip/index.tsx`; replace the `isOnTrack = totalInvesting >= totalRequired` heuristic and its derived `investingColor`/`investingCaption` with logic driven by `goalRiskSummary`: when `goalRiskSummary.total === 0` fall back to today's neutral/no-data behavior (e.g. "No SIPs logged yet" when `totalInvesting === 0`, otherwise no risk-specific caption); otherwise show `success.main`/"On track" when `goalRiskSummary.atRisk === 0`, or `warning.main`/"`{atRisk}` of `{total}` goals at risk" when not
+- [x] T016 [P] [US2] Create `src/pages/Planner/components/PlannerStatStrip/index.test.tsx` (new file) covering: all-on-track summary renders "On track"/success color, a mixed summary renders "N of M goals at risk"/warning color, `total === 0` with `totalInvesting === 0` falls back to "No SIPs logged yet", `total === 0` with `totalInvesting > 0` shows no risk caption
+- [x] T017 [US2] Pass `goalRiskSummary={goalRiskSummary}` from `src/pages/Planner/index.tsx` into its `<PlannerStatStrip>` usage
+- [x] T018 [P] [US2] Update `src/pages/Planner/index.test.tsx`'s `MockPlannerStatStrip` to capture and expose the `goalRiskSummary` prop, and add a test asserting `Planner` passes a `goalRiskSummary` consistent with the `financialGoals`/`investmentLogs` in the rendered `plannerData` fixture
+
+**Checkpoint**: Stat strip and per-goal chips agree on every plan (SC-002); `npm run test:ci` passes
+
+---
+
+## Phase 5: User Story 3 - Status stays current as the plan changes (Priority: P3)
+
+**Goal**: Editing a goal, an investment allocation's return rate, or a SIP entry updates both the per-goal chips and the stat-strip summary immediately, with no reload.
+
+**Independent Test**: Load a plan with an at-risk goal, log enough additional SIP funding to close its shortfall, and confirm its chip and the stat-strip count both flip to on-track on the same render — without a page reload — and the reverse (lowering a return rate to create a shortfall) also flips correctly.
+
+- [x] T019 [US3] Review the `useMemo` dependency arrays added in T007 (`baseline`, `goalRiskStatuses`, `goalRiskSummary`) in `src/pages/Planner/index.tsx` and confirm each recomputes on every relevant change: goal add/edit/remove (`plannerData.financialGoals`), allocation return-rate change (`plannerData.investmentAllocations`), and SIP log add/edit/remove (`plannerData.investmentLogs`); correct any missing dependency
+- [x] T020 [P] [US3] Add a test in `src/pages/Planner/index.test.tsx` that renders `Planner` with an at-risk `plannerData` fixture, captures the `goalRiskSummary`/`goalRiskStatuses` props passed to the mocked `PlannerStatStrip`/`GoalBox`, then re-renders with an updated `plannerData` (additional SIP entry closing the shortfall) and asserts the props received on the second render reflect the closed shortfall — no unmount/remount involved
+
+**Checkpoint**: All three user stories work together; full `npm run test:ci` and `npm run build` pass
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation against the spec's success criteria and edge cases.
+
+- [x] T021 Run through every step of `quickstart.md` manually (`npm start`) and confirm each passes, paying particular attention to the no-goals case (FR-006), the all-recurring case (edge case), and the two-goals-sharing-a-shortfall case (edge case)
+- [x] T022 Run `npm run test:ci` (full suite) and `npm run build`; fix any regressions
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories
+- **User Stories (Phase 3-5)**: All depend on Foundational (T003-T007) completion
+  - US1 (Phase 3), US2 (Phase 4), and US3 (Phase 5) touch different files at their leaf
+    components but each rewires the same `Planner/index.tsx` prop list (T013, T017) and shares the
+    `useMemo`s from T007 — safest done sequentially in priority order, though US1 and US2's
+    component-level work (T008-T012, T015-T016) can proceed in parallel if staffed separately
+  - US3 has no new production code of its own — it verifies/tests what T007, US1, and US2 already
+    built, so it naturally comes last
+- **Polish (Phase 6)**: Depends on all three user stories being complete
+
+### Within Each User Story
+
+- Leaf component (`GoalCard` / `PlannerStatStrip`) before the components that thread props into it
+- Tests alongside (or immediately after) the implementation task they cover
+- Story's `Planner/index.tsx` wiring task last, since it's the integration point
+
+### Parallel Opportunities
+
+- T001/T002 (Setup) in parallel
+- T003 and T006 (Foundational) in parallel with each other, but both depend on T004/T005 existing first for T006 to have something to test against — see task order above
+- T009, T011, T014 (US1 tests) can run in parallel with each other once their corresponding implementation tasks land
+- T016, T018 (US2 tests) in parallel with each other
+- US1's component tasks (T008-T009) and US2's component tasks (T015-T016) can be developed in parallel by different people, since they touch entirely different files (`GoalCard` vs. `PlannerStatStrip`)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After T004/T005/T007 (Foundational) land, these can proceed together:
+Task: "Add riskStatus prop + chip rendering to GoalCard (T008)"
+Task: "Extend GoalCard/index.test.tsx for the three riskStatus states (T009)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL — blocks all stories)
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Open the Goals drawer on a plan with mixed goal health; confirm chips are correct
+5. Demo if ready — this alone delivers the feature's entire stated value proposition
+
+### Incremental Delivery
+
+1. Setup + Foundational → derivation exists and is wired, but not yet rendered anywhere
+2. Add US1 → per-goal chips visible in the Goals drawer → demo (MVP)
+3. Add US2 → always-visible summary + reconciled stat-strip caption → demo
+4. Add US3 → confidence that both stay live as the plan changes → demo
+5. Polish → quickstart.md walkthrough + full suite/build
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- `src/domain/whatIf.ts` is touched only additively (T003, exporting an existing local constant) —
+  no behavior change to any of its existing exported functions
+- Commit after each task or logical group
+- Stop at any checkpoint to validate a story independently

--- a/src/domain/goalRiskStatus.test.ts
+++ b/src/domain/goalRiskStatus.test.ts
@@ -1,0 +1,91 @@
+import { deriveGoalRiskStatuses, summarizeGoalRisk } from './goalRiskStatus';
+import { FinancialGoal } from './FinancialGoals';
+import { GoalType } from '../types/enums';
+import { PortfolioWhatIfResult, WhatIfGoalMarker } from './whatIf';
+
+const makeGoal = (goalType: GoalType, goalName = 'Goal') =>
+  new FinancialGoal(goalName, goalType, '2024-01-01', '2030-01-01', 1_000_000);
+
+const makeMarker = (goalId: string, portfolioValueAfter: number): WhatIfGoalMarker => ({
+  goalId,
+  goalName: 'Goal',
+  date: '2030-01-01',
+  amount: 1_000_000,
+  portfolioValueAfter,
+});
+
+const makeBaseline = (markers: WhatIfGoalMarker[]): PortfolioWhatIfResult => ({
+  totalTargetAmount: 0,
+  totalInvestedValue: 0,
+  totalShortfall: 0,
+  status: 'on-track',
+  requirementPoints: [],
+  investingPoints: [],
+  markers,
+});
+
+describe('goalRiskStatus', () => {
+  describe('deriveGoalRiskStatuses', () => {
+    it('marks a one-time goal on-track when its marker has a non-negative portfolioValueAfter', () => {
+      const goal = makeGoal(GoalType.ONE_TIME);
+      const baseline = makeBaseline([makeMarker(goal.id, 50_000)]);
+
+      expect(deriveGoalRiskStatuses([goal], baseline)).toEqual({ [goal.id]: 'on-track' });
+    });
+
+    it('marks a one-time goal at-risk when its marker has a negative portfolioValueAfter', () => {
+      const goal = makeGoal(GoalType.ONE_TIME);
+      const baseline = makeBaseline([makeMarker(goal.id, -20_000)]);
+
+      expect(deriveGoalRiskStatuses([goal], baseline)).toEqual({ [goal.id]: 'at-risk' });
+    });
+
+    it('always marks a recurring goal not-evaluated, regardless of markers', () => {
+      const goal = makeGoal(GoalType.RECURRING);
+      // Even if a marker happened to exist under this goal's id, it must not be consulted.
+      const baseline = makeBaseline([makeMarker(goal.id, -1)]);
+
+      expect(deriveGoalRiskStatuses([goal], baseline)).toEqual({ [goal.id]: 'not-evaluated' });
+    });
+
+    it('marks both goals at-risk when they share a withdrawal month that overdraws the corpus', () => {
+      const goalA = makeGoal(GoalType.ONE_TIME, 'Goal A');
+      const goalB = makeGoal(GoalType.ONE_TIME, 'Goal B');
+      // Both goals' markers land on the same shared, now-negative corpus reading.
+      const baseline = makeBaseline([makeMarker(goalA.id, -5_000), makeMarker(goalB.id, -5_000)]);
+
+      expect(deriveGoalRiskStatuses([goalA, goalB], baseline)).toEqual({
+        [goalA.id]: 'at-risk',
+        [goalB.id]: 'at-risk',
+      });
+    });
+
+    it('returns an empty map for an empty goal list', () => {
+      const baseline = makeBaseline([]);
+
+      expect(deriveGoalRiskStatuses([], baseline)).toEqual({});
+    });
+  });
+
+  describe('summarizeGoalRisk', () => {
+    it('returns zero/zero for an empty statuses map', () => {
+      expect(summarizeGoalRisk({})).toEqual({ atRisk: 0, total: 0 });
+    });
+
+    it('excludes not-evaluated goals from both the numerator and denominator', () => {
+      const statuses = {
+        a: 'at-risk' as const,
+        b: 'on-track' as const,
+        c: 'not-evaluated' as const,
+      };
+
+      expect(summarizeGoalRisk(statuses)).toEqual({ atRisk: 1, total: 2 });
+    });
+
+    it('returns zero/zero for an all-recurring plan (no one-time goals evaluated)', () => {
+      const statuses = { a: 'not-evaluated' as const, b: 'not-evaluated' as const };
+
+      expect(summarizeGoalRisk(statuses)).toEqual({ atRisk: 0, total: 0 });
+    });
+  });
+});

--- a/src/domain/goalRiskStatus.ts
+++ b/src/domain/goalRiskStatus.ts
@@ -1,0 +1,56 @@
+import { FinancialGoal } from './FinancialGoals';
+import { PortfolioWhatIfResult } from './whatIf';
+import { GoalType } from '../types/enums';
+
+/**
+ * A goal's non-persisted, render-time risk classification.
+ *
+ * - `on-track` / `at-risk`: derived for one-time goals from the plan's current (unmodified)
+ *   assumptions — see `deriveGoalRiskStatuses`.
+ * - `not-evaluated`: recurring goals have no shortfall projection today, so they always get this
+ *   distinct third state rather than being silently mapped to either of the other two.
+ */
+export type GoalRiskDisplayStatus = 'on-track' | 'at-risk' | 'not-evaluated';
+
+/** Portfolio-level count for the always-visible summary. Recurring goals are never counted. */
+export type GoalRiskSummary = {
+  atRisk: number;
+  total: number;
+};
+
+/**
+ * Reads the per-goal risk signal straight off `baseline` (built from `whatIf.ts`'s
+ * `buildPortfolioWhatIfResult` with `EMPTY_ADJUSTMENTS` — i.e. the plan's own current
+ * assumptions), rather than running any new projection. `WhatIfGoalMarker.portfolioValueAfter` is
+ * already the shared corpus's value right after that goal's own withdrawal; negative means the
+ * corpus couldn't fully fund it (whether because of this goal alone or an earlier one sharing its
+ * withdrawal month) — exactly the signal this feature needs.
+ */
+export function deriveGoalRiskStatuses(
+  goals: FinancialGoal[],
+  baseline: PortfolioWhatIfResult,
+): Record<string, GoalRiskDisplayStatus> {
+  const markerByGoalId = new Map(baseline.markers.map((marker) => [marker.goalId, marker]));
+
+  const statuses: Record<string, GoalRiskDisplayStatus> = {};
+  goals.forEach((goal) => {
+    if (goal.goalType !== GoalType.ONE_TIME) {
+      statuses[goal.id] = 'not-evaluated';
+      return;
+    }
+    const marker = markerByGoalId.get(goal.id);
+    statuses[goal.id] = marker && marker.portfolioValueAfter < 0 ? 'at-risk' : 'on-track';
+  });
+  return statuses;
+}
+
+/** Portfolio-level count for the always-visible summary — recurring goals excluded entirely. */
+export function summarizeGoalRisk(
+  statuses: Record<string, GoalRiskDisplayStatus>,
+): GoalRiskSummary {
+  const evaluated = Object.values(statuses).filter((status) => status !== 'not-evaluated');
+  return {
+    atRisk: evaluated.filter((status) => status === 'at-risk').length,
+    total: evaluated.length,
+  };
+}

--- a/src/domain/whatIf.ts
+++ b/src/domain/whatIf.ts
@@ -34,6 +34,11 @@ export type Adjustments = {
   investmentReturnRates: Record<string, number>;
 };
 
+/** The "no overrides" adjustments — i.e. the plan's own current assumptions. Shared so every
+ *  caller that wants the unmodified baseline (the What If tab, the goal risk dashboard) uses the
+ *  exact same empty object rather than each redeclaring it locally. */
+export const EMPTY_ADJUSTMENTS: Adjustments = { goalInflationRates: {}, investmentReturnRates: {} };
+
 export type PortfolioWhatIfResult = {
   totalTargetAmount: number;
   totalInvestedValue: number;

--- a/src/pages/Planner/components/GoalBox/goalList.test.tsx
+++ b/src/pages/Planner/components/GoalBox/goalList.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import GoalList from './goalList';
+import { FinancialGoal } from '../../../../domain/FinancialGoals';
+import { GoalType } from '../../../../types/enums';
+import { GoalRiskDisplayStatus } from '../../../../domain/goalRiskStatus';
+
+vi.mock('../GoalCard', () => ({
+  default: function MockGoalCard({
+    goal,
+    riskStatus,
+  }: {
+    goal: FinancialGoal;
+    riskStatus?: GoalRiskDisplayStatus;
+  }) {
+    return (
+      <div data-testid={`goal-card-${goal.goalName}`} data-risk-status={riskStatus}>
+        {goal.goalName}
+      </div>
+    );
+  },
+}));
+
+const mockDispatch = vi.fn();
+
+const makeGoal = (goalName: string) =>
+  new FinancialGoal(goalName, GoalType.ONE_TIME, '2024-01-01', '2030-01-01', 500000);
+
+describe('GoalList', () => {
+  it("passes each goal's looked-up riskStatus from the goalRiskStatuses map to GoalCard", () => {
+    const goalA = makeGoal('Goal A');
+    const goalB = makeGoal('Goal B');
+
+    render(
+      <GoalList
+        goals={[goalA, goalB]}
+        investmentBreakdownForAllGoals={[]}
+        dispatch={mockDispatch}
+        goalRiskStatuses={{ [goalA.id]: 'at-risk', [goalB.id]: 'on-track' }}
+      />,
+    );
+
+    expect(screen.getByTestId('goal-card-Goal A')).toHaveAttribute('data-risk-status', 'at-risk');
+    expect(screen.getByTestId('goal-card-Goal B')).toHaveAttribute('data-risk-status', 'on-track');
+  });
+
+  it('passes undefined when a goal has no entry in goalRiskStatuses', () => {
+    const goal = makeGoal('Untracked Goal');
+
+    render(
+      <GoalList
+        goals={[goal]}
+        investmentBreakdownForAllGoals={[]}
+        dispatch={mockDispatch}
+        goalRiskStatuses={{}}
+      />,
+    );
+
+    expect(screen.getByTestId(`goal-card-${goal.goalName}`)).not.toHaveAttribute('data-risk-status');
+  });
+});

--- a/src/pages/Planner/components/GoalBox/goalList.tsx
+++ b/src/pages/Planner/components/GoalBox/goalList.tsx
@@ -4,17 +4,20 @@ import { GoalWiseInvestmentSuggestions } from '../../hooks/useInvestmentCalculat
 import { FinancialGoal } from '../../../../domain/FinancialGoals';
 import { PlannerDataAction } from '../../../../store/plannerDataReducer';
 import { Dispatch } from 'react';
+import { GoalRiskDisplayStatus } from '../../../../domain/goalRiskStatus';
 
 type GoalListProps = {
   investmentBreakdownForAllGoals: GoalWiseInvestmentSuggestions[];
   goals: FinancialGoal[];
   dispatch: Dispatch<PlannerDataAction>;
+  goalRiskStatuses: Record<string, GoalRiskDisplayStatus>;
 };
 
 const GoalList = ({
   investmentBreakdownForAllGoals,
   goals,
   dispatch,
+  goalRiskStatuses,
 }: GoalListProps) => {
   return (
     <Grid container spacing={2}>
@@ -30,6 +33,7 @@ const GoalList = ({
               dispatch={dispatch}
               currentValue={investmentBreakdown?.currentValue ?? 0}
               investmentSuggestions={investmentBreakdown?.investmentSuggestions}
+              riskStatus={goalRiskStatuses[goal.id]}
             />
           </Grid>
         );

--- a/src/pages/Planner/components/GoalBox/index.test.tsx
+++ b/src/pages/Planner/components/GoalBox/index.test.tsx
@@ -3,14 +3,25 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import GoalBox from './index';
 import { FinancialGoal } from '../../../../domain/FinancialGoals';
 import { GoalType } from '../../../../types/enums';
+import { GoalRiskDisplayStatus } from '../../../../domain/goalRiskStatus';
 
 // Mock child components to keep tests focused on GoalBox tab behavior
 vi.mock('./goalList', () => ({
-  default: function MockGoalList({ goals }: { goals: FinancialGoal[] }) {
+  default: function MockGoalList({
+    goals,
+    goalRiskStatuses,
+  }: {
+    goals: FinancialGoal[];
+    goalRiskStatuses: Record<string, GoalRiskDisplayStatus>;
+  }) {
     return (
       <div data-testid="goal-list">
         {goals.map((g) => (
-          <div key={g.id} data-testid={`goal-${g.goalName}`}>
+          <div
+            key={g.id}
+            data-testid={`goal-${g.goalName}`}
+            data-risk-status={goalRiskStatuses[g.id]}
+          >
             {g.goalName}
           </div>
         ))}
@@ -55,6 +66,7 @@ describe('GoalBox', () => {
     selectedDate,
     dispatch: mockDispatch,
     useStyledBox: false,
+    goalRiskStatuses: {},
   };
 
   afterEach(() => {
@@ -201,6 +213,26 @@ describe('GoalBox', () => {
       expect(screen.getByRole('tab', { name: /One Time/i })).toHaveAttribute(
         'aria-selected',
         'false',
+      );
+    });
+  });
+
+  describe('goalRiskStatuses forwarding', () => {
+    it('forwards the goalRiskStatuses map it is given down to GoalList unchanged', () => {
+      render(
+        <GoalBox
+          {...defaultProps}
+          financialGoals={[pendingGoal, recurringGoal]}
+          goalRiskStatuses={{ [pendingGoal.id]: 'at-risk', [recurringGoal.id]: 'not-evaluated' }}
+        />,
+      );
+
+      expect(screen.getByTestId('goal-House Fund')).toHaveAttribute('data-risk-status', 'at-risk');
+
+      fireEvent.click(screen.getByRole('tab', { name: /Recurring/i }));
+      expect(screen.getByTestId('goal-Monthly Savings')).toHaveAttribute(
+        'data-risk-status',
+        'not-evaluated',
       );
     });
   });

--- a/src/pages/Planner/components/GoalBox/index.tsx
+++ b/src/pages/Planner/components/GoalBox/index.tsx
@@ -7,6 +7,7 @@ import { GoalWiseInvestmentSuggestions } from '../../hooks/useInvestmentCalculat
 import { StyledBox } from '../../../../components/StyledBox';
 import GoalList from './goalList';
 import { GoalType } from '../../../../types/enums';
+import { GoalRiskDisplayStatus } from '../../../../domain/goalRiskStatus';
 
 type GoalBoxProps = {
   financialGoals: FinancialGoal[];
@@ -14,6 +15,7 @@ type GoalBoxProps = {
   selectedDate: string;
   dispatch: Dispatch<PlannerDataAction>;
   useStyledBox: boolean;
+  goalRiskStatuses: Record<string, GoalRiskDisplayStatus>;
 };
 
 const GoalBox = ({
@@ -22,6 +24,7 @@ const GoalBox = ({
   investmentBreakdownForAllGoals,
   dispatch,
   useStyledBox,
+  goalRiskStatuses,
 }: GoalBoxProps) => {
   const [activeTab, setActiveTab] = useState<0 | 1>(0);
 
@@ -91,6 +94,7 @@ const GoalBox = ({
                 investmentBreakdownForAllGoals={investmentBreakdownForAllGoals}
                 goals={pendingGoals}
                 dispatch={dispatch}
+                goalRiskStatuses={goalRiskStatuses}
               />
             )}
             {completedGoals.length > 0 && (
@@ -102,6 +106,7 @@ const GoalBox = ({
                   investmentBreakdownForAllGoals={investmentBreakdownForAllGoals}
                   goals={completedGoals}
                   dispatch={dispatch}
+                  goalRiskStatuses={goalRiskStatuses}
                 />
               </>
             )}
@@ -119,6 +124,7 @@ const GoalBox = ({
             investmentBreakdownForAllGoals={investmentBreakdownForAllGoals}
             goals={recurringGoals}
             dispatch={dispatch}
+            goalRiskStatuses={goalRiskStatuses}
           />
         )}
       </Box>

--- a/src/pages/Planner/components/GoalCard/index.test.tsx
+++ b/src/pages/Planner/components/GoalCard/index.test.tsx
@@ -129,4 +129,68 @@ describe('GoalCard', () => {
     );
     expect(screen.getByText(/01\/2024 - 01\/2030/)).toBeInTheDocument();
   });
+
+  describe('riskStatus chip', () => {
+    it('defaults to "Not evaluated" when no riskStatus prop is passed', () => {
+      const goal = makeOneTimeGoal();
+      render(
+        <GoalCard goal={goal} dispatch={mockDispatch} currentValue={50000} />,
+      );
+      expect(screen.getByText('Not evaluated')).toBeInTheDocument();
+    });
+
+    it('renders "On track" for riskStatus="on-track"', () => {
+      const goal = makeOneTimeGoal();
+      render(
+        <GoalCard
+          goal={goal}
+          dispatch={mockDispatch}
+          currentValue={50000}
+          riskStatus="on-track"
+        />,
+      );
+      expect(screen.getByText('On track')).toBeInTheDocument();
+    });
+
+    it('renders "At risk" for riskStatus="at-risk"', () => {
+      const goal = makeOneTimeGoal();
+      render(
+        <GoalCard
+          goal={goal}
+          dispatch={mockDispatch}
+          currentValue={50000}
+          riskStatus="at-risk"
+        />,
+      );
+      expect(screen.getByText('At risk')).toBeInTheDocument();
+    });
+
+    it('renders "Not evaluated" for riskStatus="not-evaluated"', () => {
+      const goal = makeOneTimeGoal();
+      render(
+        <GoalCard
+          goal={goal}
+          dispatch={mockDispatch}
+          currentValue={50000}
+          riskStatus="not-evaluated"
+        />,
+      );
+      expect(screen.getByText('Not evaluated')).toBeInTheDocument();
+    });
+
+    it('the risk chip is not clickable (static display only)', () => {
+      const goal = makeOneTimeGoal();
+      render(
+        <GoalCard
+          goal={goal}
+          dispatch={mockDispatch}
+          currentValue={50000}
+          riskStatus="at-risk"
+        />,
+      );
+      const chipLabel = screen.getByText('At risk');
+      // MUI Chip only renders a clickable root (role="button") when onClick is passed.
+      expect(chipLabel.closest('.MuiChip-root')).not.toHaveAttribute('role', 'button');
+    });
+  });
 });

--- a/src/pages/Planner/components/GoalCard/index.tsx
+++ b/src/pages/Planner/components/GoalCard/index.tsx
@@ -16,6 +16,7 @@ import { formatCurrency } from '../../../../types/util';
 import { PlannerDataAction } from '../../../../store/plannerDataReducer';
 import { DEFAULT_INFLATION_RATE } from '../../../../domain/constants';
 import FinancialGoalForm from '../../../../pages/Home/components/FinancialGoalForm';
+import { GoalRiskDisplayStatus } from '../../../../domain/goalRiskStatus';
 
 const INVESTMENT_COLORS = [
   '#FF9800', // Orange
@@ -25,17 +26,31 @@ const INVESTMENT_COLORS = [
   '#F44336', // Red
 ];
 
+// Static (no click/navigation) — per FR-007, this is a display-only signal.
+const RISK_STATUS_CONFIG: Record<
+  GoalRiskDisplayStatus,
+  { label: string; icon: string; color: 'success' | 'warning' | 'default' }
+> = {
+  'on-track': { label: 'On track', icon: 'check_circle', color: 'success' },
+  'at-risk': { label: 'At risk', icon: 'warning', color: 'warning' },
+  'not-evaluated': { label: 'Not evaluated', icon: 'help', color: 'default' },
+};
+
 const GoalCard = memo(
   ({
     goal,
     dispatch,
     currentValue,
     investmentSuggestions = [],
+    // Defaults to 'not-evaluated' (never a false on-track/at-risk claim) when a caller doesn't
+    // yet have a computed status to pass — e.g. existing tests predating the goal risk dashboard.
+    riskStatus = 'not-evaluated',
   }: {
     goal: FinancialGoal;
     dispatch: Dispatch<PlannerDataAction>;
     currentValue: number;
     investmentSuggestions?: InvestmentSuggestion[];
+    riskStatus?: GoalRiskDisplayStatus;
   }) => {
     const [expanded, setExpanded] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
@@ -96,7 +111,26 @@ const GoalCard = memo(
         >
           {/* Left section */}
           <Box sx={{ flex: 1, minWidth: 0 }}>
-            <Typography variant="subtitle2">{goal.goalName}</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+              <Typography variant="subtitle2">{goal.goalName}</Typography>
+              <Chip
+                size="small"
+                color={RISK_STATUS_CONFIG[riskStatus].color}
+                variant={riskStatus === 'not-evaluated' ? 'outlined' : 'filled'}
+                label={
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <span className="material-symbols-rounded" style={{ fontSize: '14px' }}>
+                      {RISK_STATUS_CONFIG[riskStatus].icon}
+                    </span>
+                    {RISK_STATUS_CONFIG[riskStatus].label}
+                  </Box>
+                }
+                sx={{
+                  height: 22,
+                  '& .MuiChip-label': { px: 1, display: 'flex', alignItems: 'center' },
+                }}
+              />
+            </Box>
             <Typography
               variant="h6"
               sx={{ fontWeight: 'bold', mt: 1, fontSize }}

--- a/src/pages/Planner/components/PlannerStatStrip/index.test.tsx
+++ b/src/pages/Planner/components/PlannerStatStrip/index.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import PlannerStatStrip from './index';
+
+describe('PlannerStatStrip', () => {
+  const baseProps = {
+    targetAmount: 1_000_000,
+    totalRequired: 20_000,
+    totalInvesting: 20_000,
+  };
+
+  it('shows "On track" when goalRiskSummary reports zero at-risk goals', () => {
+    render(
+      <PlannerStatStrip {...baseProps} goalRiskSummary={{ atRisk: 0, total: 3 }} />,
+    );
+    expect(screen.getByText('On track')).toBeInTheDocument();
+  });
+
+  it('shows "N of M goals at risk" when goalRiskSummary reports at-risk goals', () => {
+    render(
+      <PlannerStatStrip {...baseProps} goalRiskSummary={{ atRisk: 2, total: 5 }} />,
+    );
+    expect(screen.getByText('2 of 5 goals at risk')).toBeInTheDocument();
+  });
+
+  it('singularizes "1 of 1 goal at risk"', () => {
+    render(
+      <PlannerStatStrip {...baseProps} goalRiskSummary={{ atRisk: 1, total: 1 }} />,
+    );
+    expect(screen.getByText('1 of 1 goal at risk')).toBeInTheDocument();
+  });
+
+  it('falls back to "No SIPs logged yet" when nothing is being invested, even with one-time goals', () => {
+    render(
+      <PlannerStatStrip
+        {...baseProps}
+        totalInvesting={0}
+        goalRiskSummary={{ atRisk: 2, total: 2 }}
+      />,
+    );
+    expect(screen.getByText('No SIPs logged yet')).toBeInTheDocument();
+  });
+
+  it('shows no risk caption when there are no one-time goals to evaluate but SIPs are logged', () => {
+    render(
+      <PlannerStatStrip {...baseProps} goalRiskSummary={{ atRisk: 0, total: 0 }} />,
+    );
+    expect(screen.queryByText('On track')).not.toBeInTheDocument();
+    expect(screen.queryByText(/at risk/)).not.toBeInTheDocument();
+  });
+
+  it('falls back to "No SIPs logged yet" when there are no one-time goals and nothing invested', () => {
+    render(
+      <PlannerStatStrip
+        {...baseProps}
+        totalInvesting={0}
+        goalRiskSummary={{ atRisk: 0, total: 0 }}
+      />,
+    );
+    expect(screen.getByText('No SIPs logged yet')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Planner/components/PlannerStatStrip/index.tsx
+++ b/src/pages/Planner/components/PlannerStatStrip/index.tsx
@@ -2,6 +2,7 @@ import { Box, Chip, Typography } from '@mui/material';
 import { FinancialGoal } from '../../../../domain/FinancialGoals';
 import { TermType } from '../../../../types/enums';
 import { formatCurrency } from '../../../../types/util';
+import { GoalRiskSummary } from '../../../../domain/goalRiskStatus';
 
 export type PlannerStatStripProps = {
   targetAmount: number;
@@ -10,6 +11,7 @@ export type PlannerStatStripProps = {
   financialGoals?: FinancialGoal[];
   onGoalsClick?: () => void;
   onAddGoal?: () => void;
+  goalRiskSummary: GoalRiskSummary;
 };
 
 const TERM_CONFIG: { type: TermType; label: string; color: string }[] = [
@@ -59,14 +61,20 @@ const StatTile = ({
   </Box>
 );
 
-const PlannerStatStrip = ({ targetAmount, totalRequired, totalInvesting, financialGoals, onGoalsClick, onAddGoal }: PlannerStatStripProps) => {
-  const isOnTrack = totalInvesting >= totalRequired;
-  const investingColor = isOnTrack ? 'success.main' : totalInvesting > 0 ? 'warning.main' : 'text.secondary';
+const PlannerStatStrip = ({ targetAmount, totalRequired, totalInvesting, financialGoals, onGoalsClick, onAddGoal, goalRiskSummary }: PlannerStatStripProps) => {
+  // Sourced from the same per-goal risk computation as the goal risk dashboard's chips (018),
+  // rather than a standalone totalInvesting >= totalRequired comparison — so this caption and the
+  // per-goal chips can never disagree about the same plan (FR-009).
+  const hasOneTimeGoals = goalRiskSummary.total > 0;
+  const isAtRisk = hasOneTimeGoals && goalRiskSummary.atRisk > 0;
+  const investingColor = !hasOneTimeGoals ? 'text.secondary' : isAtRisk ? 'warning.main' : 'success.main';
   const investingCaption = totalInvesting === 0
     ? 'No SIPs logged yet'
-    : isOnTrack
-    ? 'On track'
-    : `${formatCurrency(totalRequired - totalInvesting)} short`;
+    : !hasOneTimeGoals
+    ? undefined
+    : isAtRisk
+    ? `${goalRiskSummary.atRisk} of ${goalRiskSummary.total} goal${goalRiskSummary.total === 1 ? '' : 's'} at risk`
+    : 'On track';
 
   const termChips = TERM_CONFIG
     .map(({ type, label, color }) => ({

--- a/src/pages/Planner/hooks/useWhatIf.ts
+++ b/src/pages/Planner/hooks/useWhatIf.ts
@@ -5,6 +5,7 @@ import {
   Adjustments,
   buildPortfolioWhatIfResult,
   calculateRequiredTopUp,
+  EMPTY_ADJUSTMENTS,
   PortfolioWhatIfResult,
   WhatIfTopUpResult,
 } from '../../../domain/whatIf';
@@ -13,8 +14,6 @@ export type InvestmentBaseline = {
   investmentName: string;
   expectedReturnPercentage: number;
 };
-
-const EMPTY_ADJUSTMENTS: Adjustments = { goalInflationRates: {}, investmentReturnRates: {} };
 
 export type UseWhatIfResult = {
   oneTimeGoals: PlannerData['financialGoals'];

--- a/src/pages/Planner/index.test.tsx
+++ b/src/pages/Planner/index.test.tsx
@@ -23,10 +23,24 @@ vi.mock('./components/Pagetour', () => ({
 }));
 
 vi.mock('./components/PlannerStatStrip', () => ({
-  default: function MockPlannerStatStrip({ onGoalsClick, onAddGoal, financialGoals }: { onGoalsClick?: () => void; onAddGoal?: () => void; financialGoals?: { getTermType: () => string }[] }) {
+  default: function MockPlannerStatStrip({
+    onGoalsClick,
+    onAddGoal,
+    financialGoals,
+    goalRiskSummary,
+  }: {
+    onGoalsClick?: () => void;
+    onAddGoal?: () => void;
+    financialGoals?: { getTermType: () => string }[];
+    goalRiskSummary?: { atRisk: number; total: number };
+  }) {
     const count = financialGoals?.length ?? 0;
     return (
-      <div data-testid="planner-stat-strip">
+      <div
+        data-testid="planner-stat-strip"
+        data-risk-at-risk={goalRiskSummary?.atRisk}
+        data-risk-total={goalRiskSummary?.total}
+      >
         {onGoalsClick && count > 0 && (
           <button onClick={onGoalsClick}>{count} Goal{count !== 1 ? 's' : ''}</button>
         )}
@@ -212,5 +226,44 @@ describe('Planner', () => {
     const plannerData = new PlannerData([makeGoal()]);
     renderPlanner({ plannerData });
     expect(screen.getByTestId('planner-stat-strip')).toBeInTheDocument();
+  });
+
+  it('passes a goalRiskSummary consistent with an unfunded one-time goal (at risk)', () => {
+    // makeGoal() is a one-time goal with no logged SIPs (default empty investmentLogs) — its
+    // shared corpus can't cover its target amount, so it must be counted at-risk.
+    const plannerData = new PlannerData([makeGoal()]);
+    renderPlanner({ plannerData });
+    const statStrip = screen.getByTestId('planner-stat-strip');
+    expect(statStrip).toHaveAttribute('data-risk-at-risk', '1');
+    expect(statStrip).toHaveAttribute('data-risk-total', '1');
+  });
+
+  it('passes a goalRiskSummary of zero/zero when there are no goals', () => {
+    renderPlanner({ plannerData: new PlannerData() });
+    const statStrip = screen.getByTestId('planner-stat-strip');
+    expect(statStrip).toHaveAttribute('data-risk-at-risk', '0');
+    expect(statStrip).toHaveAttribute('data-risk-total', '0');
+  });
+
+  it('recomputes goalRiskSummary live when investmentLogs change, without remounting', () => {
+    const goal = makeGoal();
+    const { rerender } = renderPlanner({ plannerData: new PlannerData([goal]) });
+
+    expect(screen.getByTestId('planner-stat-strip')).toHaveAttribute('data-risk-at-risk', '1');
+
+    // Log enough SIP funding to close the shortfall — same goal, same component instance.
+    const funded = new PlannerData([goal], undefined, [
+      {
+        id: 'sip-1',
+        name: 'Test Fund',
+        type: 'Equity',
+        monthlyAmount: 30_000,
+        expectedReturnPct: 10,
+        startDate: dayjs().format('YYYY-MM-DD'),
+      },
+    ]);
+    rerender(<Planner plannerData={funded} dispatch={mockDispatch} />);
+
+    expect(screen.getByTestId('planner-stat-strip')).toHaveAttribute('data-risk-at-risk', '0');
   });
 });

--- a/src/pages/Planner/index.tsx
+++ b/src/pages/Planner/index.tsx
@@ -31,6 +31,8 @@ import GoalGrowthChart from './components/GoalGrowthChart';
 import WhatIf from './components/WhatIf';
 import AddGoalPopup from '../Home/components/AddGoalPopup';
 import { GoalSuggestion } from '../../domain/investmentLog';
+import { buildPortfolioWhatIfResult, EMPTY_ADJUSTMENTS } from '../../domain/whatIf';
+import { deriveGoalRiskStatuses, summarizeGoalRisk } from '../../domain/goalRiskStatus';
 
 type PlannerProps = {
   plannerData: PlannerData;
@@ -135,6 +137,29 @@ const Planner = ({
     [plannerData.investmentLogs],
   );
 
+  // Goal risk dashboard (018): the plan's own current assumptions, no What-If overrides — the
+  // exact same baseline the What If tab computes, reused here to drive an always-visible signal.
+  const goalRiskBaseline = useMemo(
+    () =>
+      buildPortfolioWhatIfResult(
+        plannerData.financialGoals,
+        plannerData.investmentLogs,
+        plannerData.investmentAllocations,
+        EMPTY_ADJUSTMENTS,
+      ),
+    [plannerData.financialGoals, plannerData.investmentLogs, plannerData.investmentAllocations],
+  );
+
+  const goalRiskStatuses = useMemo(
+    () => deriveGoalRiskStatuses(plannerData.financialGoals, goalRiskBaseline),
+    [plannerData.financialGoals, goalRiskBaseline],
+  );
+
+  const goalRiskSummary = useMemo(
+    () => summarizeGoalRisk(goalRiskStatuses),
+    [goalRiskStatuses],
+  );
+
   const completedGoals = useMemo(
     () => plannerData.financialGoals.filter((goal) => dayjs(selectedDate).isAfter(goal.getTargetDate())),
     [plannerData.financialGoals, selectedDate],
@@ -225,6 +250,7 @@ const Planner = ({
               financialGoals={plannerData.financialGoals}
               onGoalsClick={() => setShowGoalsDrawer(true)}
               onAddGoal={() => setIsAddGoalOpen(true)}
+              goalRiskSummary={goalRiskSummary}
             />
 
             <Tabs
@@ -293,6 +319,7 @@ const Planner = ({
             selectedDate={selectedDate}
             dispatch={dispatch}
             useStyledBox={false}
+            goalRiskStatuses={goalRiskStatuses}
           />
         </Box>
       </Drawer>


### PR DESCRIPTION
## Summary
Surfaces at-risk vs on-track status per goal on the main Planner screen using the plan's current (non-What-If) assumptions, reusing the existing goal attainment logic from `src/domain/whatIf.ts` — the same rules that already power the What-If tab's live projection now also drive a persistent, always-visible indicator, without opening the What-If tab or touching sliders.

## What changed
- **`src/domain/goalRiskStatus.ts`** (new): `deriveGoalRiskStatuses` / `summarizeGoalRisk` — pure functions that read `whatIf.ts`'s existing `PortfolioWhatIfResult` markers. One-time goals get `on-track`/`at-risk` from marker sign; recurring goals always get the explicit third state `not-evaluated` (never silently defaulted).
- **`src/domain/whatIf.ts`**: additive only — exports a shared `EMPTY_ADJUSTMENTS` baseline constant, now reused by `useWhatIf.ts` too. No existing behavior changed.
- **`GoalCard`**: new static (non-clickable) status chip per goal, defaults to `not-evaluated` for backward compat.
- **`GoalBox`/`goalList`**: thread the per-goal status map down to cards.
- **`PlannerStatStrip`**: "Monthly Investing" caption/color now sourced from the same computation instead of a standalone heuristic, so it can never disagree with the per-goal chips (FR-009).
- **`Planner/index.tsx`**: three `useMemo`s wire it together at render time; nothing new persisted to `PlannerData`/localStorage/Google Drive.

Full spec-kit trail in `specs/018-goal-risk-dashboard/` (spec, clarifications, research, data-model, plan, tasks — all 22 tasks complete).

## Verification
- `tsc --noEmit` — clean
- `npm run test:ci` — 684/684 tests passing (64 test files)
- `npm run build` — succeeds
- `src/domain` coverage: 98.53% statements / 88.1% branches / 99.13% functions / 98.87% lines

## Notes
- Reuse-not-modify: the simulation engine itself is untouched: the dashboard only *reads* existing `whatIf.ts` output.
- Not merging/releasing yet per plan — opening for review now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)