### PR TITLE
chore: remove unused @adi-prasetyo/react-joyride dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "gbfp",
       "version": "0.1.0",
       "dependencies": {
-        "@adi-prasetyo/react-joyride": "^2.9.3-adp.1",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^6.1.7",
@@ -54,41 +53,6 @@
         "@rolldown/binding-linux-x64-gnu": "*",
         "@rollup/rollup-linux-x64-gnu": "*",
         "lightningcss-linux-x64-gnu": "*"
-      }
-    },
-    "node_modules/@adi-prasetyo/react-joyride": {
-      "version": "2.9.3-adp.1",
-      "resolved": "https://registry.npmjs.org/@adi-prasetyo/react-joyride/-/react-joyride-2.9.3-adp.1.tgz",
-      "integrity": "sha512-MbUioo3kskOVZCF1kUXXQo+K0HN0gEnIIi+PRaU9Idtu9mum64tkPDH0SEhwdO9S159s4wQAxCKv55m6MiLdrA==",
-      "license": "MIT",
-      "dependencies": {
-        "@gilbarbara/deep-equal": "^0.3.1",
-        "deep-diff": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "is-lite": "^1.2.1",
-        "react-floater": "^0.9.4",
-        "react-innertext": "^1.1.5",
-        "react-is": "^19.1.1",
-        "scroll": "^3.0.1",
-        "scrollparent": "^2.1.0",
-        "tree-changes": "^0.11.3",
-        "type-fest": "^4.41.0"
-      },
-      "peerDependencies": {
-        "react": "15 - 19",
-        "react-dom": "15 - 19"
-      }
-    },
-    "node_modules/@adi-prasetyo/react-joyride/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -685,12 +649,6 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
-    },
-    "node_modules/@gilbarbara/deep-equal": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.3.1.tgz",
-      "integrity": "sha512-I7xWjLs2YSVMc5gGx1Z3ZG1lgFpITPndpi8Ku55GeEIKpACCPQNS/OTqQbxgTCfq0Ncvcc+CrFov96itVh6Qvw==",
-      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -3308,37 +3266,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/deep-diff": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
-      "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT"
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=16.0.0"
-      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -5151,12 +5084,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-lite": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-1.2.1.tgz",
-      "integrity": "sha512-pgF+L5bxC+10hLBgf6R2P4ZZUBOQIIacbdo8YvuCP8/JvsWxG7aZ9p10DYuLtifFci4l3VITphhMlMV4Y+urPw==",
-      "license": "MIT"
-    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -6747,22 +6674,6 @@
         "react": "^19.2.4"
       }
     },
-    "node_modules/react-floater": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/react-floater/-/react-floater-0.9.4.tgz",
-      "integrity": "sha512-fVsomyiDzWEJHSdQ9/uLDZfe6VSoULfO/23BLXFAtmp83ObCC4SFwaDlDc2EZCyvqfOnyu6KaoQHoXolinourQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.11.8",
-        "deepmerge-ts": "^7.1.0",
-        "is-lite": "^1.2.1",
-        "tree-changes-hook": "^0.11.2"
-      },
-      "peerDependencies": {
-        "react": "16.8 - 19",
-        "react-dom": "16.8 - 19"
-      }
-    },
     "node_modules/react-hook-form": {
       "version": "7.71.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
@@ -6777,16 +6688,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
-      }
-    },
-    "node_modules/react-innertext": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
-      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": ">=0.0.0 <=99",
-        "react": ">=0.0.0 <=99"
       }
     },
     "node_modules/react-is": {
@@ -7112,18 +7013,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
-    },
-    "node_modules/scroll": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
-      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==",
-      "license": "MIT"
-    },
-    "node_modules/scrollparent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
-      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
-      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -7717,29 +7606,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tree-changes": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.11.3.tgz",
-      "integrity": "sha512-r14mvDZ6tqz8PRQmlFKjhUVngu4VZ9d92ON3tp0EGpFBE6PAHOq8Bx8m8ahbNoGE3uI/npjYcJiqVydyOiYXag==",
-      "license": "MIT",
-      "dependencies": {
-        "@gilbarbara/deep-equal": "^0.3.1",
-        "is-lite": "^1.2.1"
-      }
-    },
-    "node_modules/tree-changes-hook": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/tree-changes-hook/-/tree-changes-hook-0.11.3.tgz",
-      "integrity": "sha512-cNHPuFc5Qbi2B74VqSqL/Ee/l4n0SFfzYKTnXYViJW1yCFZ0bl97QsgUIw9vdQtqpWDwo83mpNkGUvcjeQc0Xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@gilbarbara/deep-equal": "^0.3.1",
-        "tree-changes": "0.11.3"
-      },
-      "peerDependencies": {
-        "react": "16.8 - 19"
       }
     },
     "node_modules/trim-repeated": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": false,
   "homepage": "https://goal-based-financial-planner.github.io/goal-based-financial-planner",
   "dependencies": {
-    "@adi-prasetyo/react-joyride": "^2.9.3-adp.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^6.1.7",


### PR DESCRIPTION
## Summary
Fixes 3 high-severity `npm audit` findings (GHSA-ggr8-5vv4-36mx — stack exhaustion in `deepmerge-ts <8.0.0`), pulled in transitively via `react-floater` <- `@adi-prasetyo/react-joyride`.

## Why this is safe
`@adi-prasetyo/react-joyride` was dead weight: the app's guided tour migrated to `driver.js` a while back (see `src/pages/Planner/components/Pagetour`), and no source file imports `react-joyride` anymore. Removing the unused dependency (rather than `npm audit fix --force`, which would have force-upgraded/replaced an otherwise-unused package with a breaking change) drops all 3 vulnerable transitive deps outright.

## Verification
- `npm audit` — 0 vulnerabilities (was 3 high)
- `tsc --noEmit` — clean
- `npm run test:ci` — 659/659 tests passing
- `npm run build` — succeeds

## Scope note
Independent of #26 (goal risk dashboard) — no file overlap (`package.json`/`package-lock.json` only), branched off `main` directly so it can merge on its own timeline without waiting on feature review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)