### PR TITLE
chore: add Google Search Console verification meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
       content="investment planning, financial goals, goal-based investment, savings plan, investment strategy, financial planning tool, investment calculator, investment portfolio builder, long term goal planning, Systematic investment planning, SIP, Mutual fund planning, Mutual Fund SIP calculator"
     />
     <meta name="author" content="Goal Based Financial Planner" />
+    <meta name="google-site-verification" content="cuYLqTKkQJOSx_b-Zh6m7c_kIRZ9L7hfzNI1x4dhZXE" />
 
     <!-- Canonical URL -->
     <link rel="canonical" href="https://goal-based-financial-planner.github.io/goal-based-financial-planner/" />


### PR DESCRIPTION
Adds the `google-site-verification` meta tag for the GitHub Pages URL-prefix property in Search Console (the HTML-file method offered a different filename than the one already deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)